### PR TITLE
contributing: Add documentation on suggest changes feature

### DIFF
--- a/content/en/docs/contributing/suggest-changes.md
+++ b/content/en/docs/contributing/suggest-changes.md
@@ -1,0 +1,17 @@
+---
+title: Suggestions
+date: 2022-02-04T14:09:21+09:00
+draft: false
+weight: 504
+---
+
+## Suggestions
+
+When reviewing pull requests you can directly [suggest changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request) to the original author.
+Suggestions are direct updates to the code (or comments or documentation).
+They are made in the review screen of a pull request.
+
+Suggestions will then be [incorporated](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes) by the author.
+The reviewer will be added as co-author to the commit resulting from suggested changes.
+
+Of course, the author can simply edit the submission on their own system and add the suggested changes by hand.

--- a/content/en/docs/contributing/suggestions.md
+++ b/content/en/docs/contributing/suggestions.md
@@ -1,8 +1,0 @@
----
-title: Suggestions
-date: 2020-01-11T14:09:21+09:00
-draft: false
-weight: 504
----
-
-## Suggestions


### PR DESCRIPTION
The GitHub feature to suggest changes allows the reviewer to directly make suggested edits on the submission (PR).