### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+node_modules/
+resources/_gen


### PR DESCRIPTION
Currently, the `node_modules` folder is not ignored, and this causes a lot of changes to be tracked, which shouldn't ever be pushed. Also, the `package-lock.json` is generated by `npm install`, and should be ignored.