### PR TITLE
Adding pip3 package installation because it needed to be installed separately in order to run next command.

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -32,8 +32,11 @@ apt-get install -y --no-install-recommends \
   unzip \
   uuid-runtime \
   python3 \
-  python3-setuptools
+  python3-setuptools \
+  python3-pip
 ```
+
+
 
 To install kraft simply run:
 


### PR DESCRIPTION
pip3 is used to install kraft, it can be installed by installing python3-pip package. It was not included on getting-started page, I have included it.