### PR TITLE
docs/develop: Remove reference to metrics page

### DIFF
--- a/content/en/docs/develop/adding-metrics.md
+++ b/content/en/docs/develop/adding-metrics.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Metrics
 date: 2020-01-11T14:09:21+09:00
-draft: false
+draft: true
 weight: 512
 ---
 


### PR DESCRIPTION
The metrics support (via ukstore) is not yet upstream. Remove reference to the `docs/develop/adding-metrics.md` page by marking it draft (`draft: true`).