### PR TITLE
docs/getting-started: Add the kraft list update step

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -90,9 +90,13 @@ Help:
 The simplest way to get the sources for, build and run an application is by running the following commands:
 
 ```console
-kraft list
-kraft up -p PLATFORM -m ARCHITECTURE APP
+$ kraft list update
+$ kraft list
+$ kraft up -p PLATFORM -m ARCHITECTURE APP
 ```
+
+You may need to run `kraft list update` using a GitHub token.
+More details on the [usage page](docs/usage/dependencies).
 
 You can also build and run an applications from the existing templates by using the `-t` option.
 For example, building and running the [helloworld app](https://github.com/unikraft/app-helloworld):


### PR DESCRIPTION
This is related to this [issue](https://github.com/unikraft/unikraft/issues/449).
It should be merged after #50, for the github token reference.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>