### PR TITLE
hackathons: Add entry for Unikraft Aachen Hackathon

### DIFF
--- a/content/en/community/hackathons/2022-06-aachen/_index.md
+++ b/content/en/community/hackathons/2022-06-aachen/_index.md
@@ -1,0 +1,55 @@
+---
+title: Lyon Hackathon
+date: 2022-06-96T13:40:00+02:00
+draft: false
+collapsible: true
+description: Information on the Aachen Unikraft Hackathon, June 25-26, 2022
+---
+
+## Aachen Unikraft Hackathon
+
+Unikraft and [Rheinisch-Westfälische Technische Hochschule Aachen (RWTH Aachen University)](https://www.rwth-aachen.de) come together to organize the **Unikraft Aachen Hackathon** to be held Saturday and Sunday, June 25-26, 2022.
+The hackathon will take place face-to-face at RWTH Aachen.
+
+### Registration
+
+To take part in the hackathon please fill this [registration form](https://forms.gle/FxuP29ytbrW7ERUy9).
+
+### People
+
+The hackathon will take place at the RWTH Aachen:
+Room 00.24, Main Building, E.ON Energy Research Center, RWTH Aachen University, Mathieustraße 10, 52074 Aachen, Germany.
+See the address [Google Maps](https://goo.gl/maps/kKjJyUxnb1BUnGRBA).
+
+The host of the hackathon is [Stefan Lankes](https://www.acs.eonerc.rwth-aachen.de/go/id/fqxm/lidx/1).
+
+As part of the Unikraft community [Răzvan Deaconescu](https://github.com/razvand/) (UPB) will be present on-site for the hackathon.
+Other members of the Unikraft community will provide online support on [Discord](https://bit.ly/UnikraftDiscord).
+
+### Schedule
+
+**Saturday, June 25, 2022**
+
+| Time (CET)    | Session                                             |
+| ------------- | --------------------------------------------------- |
+| 10:00 - 10:15 | High-level presentation of unikernels and Unikraft |
+| 10:15 - 11:15 | Introduction to Unikraft. First steps in configuring, building |
+| 11:15 - 11:30 | Break |
+| 11:30 - 12:45 | Inside Unikraft: Building, configuring, using different libraries |
+| 12:45 - 14:00 | Lunch |
+| 14:00 - 15:00 | Debugging in Unikraft |
+| 15:00 - 16:00 | Running (Complex) Application in Unikraft |
+| 16:00 - 16:15 | Break |
+| 16:15 - 17:30 | RustyHermit |
+
+**Sunday, June 26, 2022**
+
+| Time (CET)    | Session                                             |
+| ------------- | --------------------------------------------------- |
+| 10:00 - 09:15 | Overview of hackathon challenges |
+| 10:15 - 11:30 | Tutorial on porting applications |
+| 11:30 - 11:45 | Break |
+| 11:45 - 12:45 | Work on hackathon challenges |
+| 12:45 - 14:00 | Lunch |
+| 14:00 - 17:30 | Work on hackathon challenges |
+| 17:30 - 17:45 | Results, final remarks |

--- a/content/en/community/hackathons/2022-06-aachen/_index.md
+++ b/content/en/community/hackathons/2022-06-aachen/_index.md
@@ -1,9 +1,10 @@
 ---
-title: Lyon Hackathon
+title: Aachen 2022
 date: 2022-06-96T13:40:00+02:00
 draft: false
 collapsible: true
 description: Information on the Aachen Unikraft Hackathon, June 25-26, 2022
+image: /assets/imgs/2022-06-hack-aachen.png
 ---
 
 ## Aachen Unikraft Hackathon


### PR DESCRIPTION
Hackathon will take place on June 25-26, 2022, at RWTH Aachen.