### PR TITLE
Add Makefile build to Getting Started

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -13,6 +13,8 @@ The easiest way to get started with Unikraft is to use the command-line utility
 running Unikraft applications.  With `kraft` you can seamlessly create a build
 environment for your unikernel and painlessly manage dependencies for its build.
 
+As an alternative to `kraft` it is also possible to build Unikraft using a regular [`Makefile`](docs/getting-started/#building-unikraft-via-makefile).
+
 ## Installing the CLI companion tool `kraft`
 
 The kraft tool and Unikraft build system have a number of package requirements;
@@ -103,3 +105,95 @@ For more information about all the steps behind `kraft up`, check [Creating an A
 For more information about the `up` command type kraft up -h.
 For more information about kraft type kraft -h or read the documentation at Unikraft’s website.
 If you find any problems please fill out an issue. Thank you!
+
+## Building Unikraft via `Makefile`
+
+To manually set up the build environment for the [helloworld app](https://github.com/unikraft/app-helloworld), we first have to create a specific directory structure:
+```
+ my-unikernel
+      ├────apps
+      │      └─app-helloworld     <- helloworld application
+      ├─── libs                   <- additional libraries go here
+      └─── unikraft               <- Unikraft core
+```
+We can do this by executing the following sequence of commands:
+```bash
+$ mkdir my-unikernel
+$ cd my-unikernel
+$ git clone https://github.com/unikraft/unikraft
+$ mkdir libs
+$ mkdir apps
+$ cd apps
+$ git clone https://github.com/unikraft/app-helloworld
+$ cd app-helloworld
+```
+All following configuration and build operations are done from within the helloworld application folder.
+Notice that it already contains a `Makefile` that looks like this:
+```Makefile
+UK_ROOT ?= $(PWD)/../../unikraft
+UK_LIBS ?= $(PWD)/../../libs
+LIBS :=
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)
+```
+In the first two lines, we provide the paths to the Unikraft core repository and the directory where we can put additional libraries.
+Since the helloworld application uses `nolibc` as C library, which comes with the Unikraft core, we do not have any external dependencies.
+We thus do not have to download or reference any libraries in the `Makefile` and can leave the `LIBS` variable empty.
+
+
+With the `Makefile` present and the directory structure correctly set up, we are able to configure the unikernel as the next step.
+This will allow us to select the target architecture (e.g., aarch64 or x86-64) and platform (e.g., KVM or Xen).
+```bash
+$ make menuconfig
+```
+By default the build system selects x86-64 as target architecture, so we only have to choose a target platform.
+We will decide for KVM by navigating to the `Platform Configuration | KVM guest` option and selecting it.
+Afterwards, we save and exit the configuration menu.
+
+You can then build the unikernel with:
+```bash
+$ make
+```
+Consider adding `-jX` with `X` being the number of CPUs in your machine to speed up the build process.
+
+When the build completes you will have a Unikraft-based kernel image (`build/app-helloworld_kvm-x86_64`) that you can start with QEMU/KVM using the `-kernel` option.
+See [here](docs/operations/plats/kvm) for further information on running the unikernel with KVM.
+
+## Adding external dependencies
+
+When the application becomes more complex, it is likely that not all functionality is included in the Unikraft core repository.
+As you might have noticed already from the code organization in the core repository (`lib/*`), Unikraft puts an emphasis on encapsulating functionality in libraries that can be easily added, removed, or replaced to tailor the unikernel to the application's needs.
+
+To add a library you simply clone it into the `libs` directory created earlier.
+In this example, we add the lightweight IP (lwip) network stack [lib-lwip](https://github.com/unikraft/lib-lwip):
+```bash
+$ cd my-unikernel
+$ cd libs
+$ git clone https://github.com/unikraft/lib-lwip
+```
+Next, we have reference the library in the `Makefile` of `app-helloworld` so that it becomes available for selection in the configuration:
+```Makefile
+UK_LIBS ?= $(PWD)/../../libs
+
+LIBS := $(UK_LIBS)/lib-lwip
+#LIBS := $(LIBS-y):$(UK_LIBS)/lib-X
+```
+We can now re-run
+```bash
+make menuconfig
+```
+and select `lwip` in the `Library Configuration` sub-menu.
+We can then rebuild the unikernel, by running:
+```bash
+$ make clean
+$ make prepare
+$ make
+```
+The `prepare` step gives the build system the chance to pull the actual source code for `lwip` and apply necessary patches to make it work with Unikraft. This has to be done only once after adding a new library.
+
+Note that the build may fail because depending on the configuration, `lwip` requires a more extensive C library (e.g., [newlib](https://github.com/unikraft/lib-newlib)) and a POSIX threads implementation (e.g., [pthread-embedded](https://github.com/unikraft/lib-pthread-embedded)).
+You can add these additional dependencies just as described.


### PR DESCRIPTION
The current Getting Started page only describes how to setup and build Unikraft with `kraft`. However, sometimes it makes sense to work with a `Makefile` directly. This commit adds a description on how to do this.