### PR TITLE
Add faq directory structure

### DIFF
--- a/content/en/docs/common-issues/all.md
+++ b/content/en/docs/common-issues/all.md
@@ -1,11 +1,11 @@
 ---
 title: FAQ
-date: 2020-01-11T14:09:21+09:00
-draft: false
-weight: 1000
+draft: true
 ---
 
 ## Frequently Asked Questions
+
+{{< readfile file="/docs/common-issues/content/Frequently-Asked-Questions.md" markdown="true" >}}
 
 ### Why Unikraft and not a container?
 

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_Can-I-use-Unikraft-code-in-commercial-products?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_Can-I-use-Unikraft-code-in-commercial-products?.md
@@ -1,0 +1,2 @@
+A: Yes. Unikraft uses a [BSD-3 license](https://opensource.org/licenses/BSD-3-Clause), which allows use in commercial products.
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_Can-Unikraft-run-bare-metal?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_Can-Unikraft-run-bare-metal?.md
@@ -1,0 +1,2 @@
+A: Currently no, but support for running bare-metal on [RasberryPI](https://www.raspberrypi.org/) is being worked on.
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-want-to-join-the-Unikraft-community-as-a-contributor.-What-do-I-do?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-want-to-join-the-Unikraft-community-as-a-contributor.-What-do-I-do?.md
@@ -1,0 +1,4 @@
+A: First, join our community server on [Discord](https://bit.ly/UnikraftDiscord).
+Then, send a Pull Request, if you already have an idea of contribution, or ask the community for some contribuition ideas.
+For more details, see the [Contributing](/docs/contributing/) section. 
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-want-to-port-an-application-on-top-of-Unikraft.-What-do-I-do?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-want-to-port-an-application-on-top-of-Unikraft.-What-do-I-do?.md
@@ -1,0 +1,4 @@
+A: First time porting an application in Unikraft can be overwhelming.
+Follow the [Porting](/docs/develop/porting/) section of the documentation.
+If you get stuck somewhere, ask in the community, and someone will help.
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-was-assigned-a-reviewer-to-a-pull-request.-What-do-I-do?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_I-was-assigned-a-reviewer-to-a-pull-request.-What-do-I-do?.md
@@ -1,0 +1,5 @@
+A: Make sure you understand the work that was submitted.
+If you have questions, ask the author.
+Make sure the submitted changes follow the [coding-style](/docs/contributing/coding-style/) standards.
+Then follow the [Reviewing](/docs/contributing/review-process/) documentation to approve the Pull Request.
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_Some-steps-fail-when-trying-to-build---run-a-Unikraft-application.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_Some-steps-fail-when-trying-to-build---run-a-Unikraft-application.md
@@ -1,0 +1,5 @@
+A: First, ask in the community about the problem you encountered.
+Most of the time, the issues are common, and known in the community.
+You can also do some debugging on your own.
+For details, see the [Debugging](/docs/develop/debugging/) section.
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_When-is-the-next-Unikraft-release-going-to-take-place?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_When-is-the-next-Unikraft-release-going-to-take-place?.md
@@ -1,0 +1,3 @@
+A: The releases are planned once every 2 months, in general.
+You can see the planning for the next release on [GitHub](https://github.com/unikraft/unikraft/milestones)
+

--- a/content/en/docs/common-issues/content/Frequently-Asked-Questions_Why-Unikraft-and-not-a-container?.md
+++ b/content/en/docs/common-issues/content/Frequently-Asked-Questions_Why-Unikraft-and-not-a-container?.md
@@ -1,0 +1,4 @@
+A: Unikraft is lightweight, faster than a container, while having the security of a virtual machine.
+Best of both worlds.
+For more details, see the [Performance](/docs/features/performance/) and [Security](/docs/features/security/) sections.
+


### PR DESCRIPTION
This pr adds a directory structure for common issues and `faqs`, similar to what we have for the hackathon sessions.
All the content is placed inside `docs/common-issues/content` and refered in `docs/faq.md` via the `readfile` shortcode.

Likely we will have another front page where common issues will be added since they refer directly to issues, not questions, but I would suggest we keep the content in the same `docs/common-issues/content` directory and we name the issues something like `Common-Issues_Issue-Name.md`, while  the name of the frequently asked questions will look like the ones in this commit: `Frequently-Asked-Questions_Question-Name.md`.
Any other ideas on this are welcome.

Content is taken from #31.

Signed-off-by: cristian-vijelie <cristianvijelie@gmail.com>
Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>