### PR TITLE
docs/porting: Add patching an application section

### DIFF
--- a/.github/workflows/rules/md101.js
+++ b/.github/workflows/rules/md101.js
@@ -17,8 +17,6 @@ const keywords = [
     new WordPattern("traceroute"),
     new WordPattern("sudo"),
     new WordPattern("(?<!(system |ISRG ))root(?! ca)", { suggestion: "root" }),// match "root", but not "root CA", "MacOS System Root" and "ISRG Root X1"
-    new WordPattern("true"),
-    new WordPattern("false"),
     new WordPattern("jps"),
     new WordPattern("name=value"),
     new WordPattern("key=value"),

--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -11,12 +11,14 @@ module.exports = {
       var actual_lines = inline.content.split("\n");
       actual_lines.forEach((line, index, arr) => {
 		let outside = true;
+		let outside_ticks = true;
 		let count = 0;
 		Array.from(line).forEach((char) => {
-			if ((char == "." || char == "?" || char == "!") && outside) {
+			if ((char == "." || char == "?" || char == "!") &&
+				(outside && outside_ticks)) {
 				count++;
 			}
-			if (char == "`") outside = !outside;
+			if (char == "`") outside_ticks = !outside_ticks;
 			if (char == "[") outside = false;
 			if (char == "(") outside = false;
 			if (char == "]") outside = true;

--- a/content/en/docs/develop/porting.md
+++ b/content/en/docs/develop/porting.md
@@ -48,7 +48,7 @@ It is an excellent application to be run as a Unikernel for several reasons:
 
 Understanding some aspects of how an application works, particularly how it is built, is required when bringing it to Unikraft.
 Usually during the porting process we also end up diving through the source code, and in the worst-case scenario, have to make a change to it.
-More on this is covered in the [Patching](./docs/develop/patching) section.
+More on this is covered in the [Patching](docs/develop/porting/#patching-the-application) section.
 
 Let's start by simply trying to follow the steps to compile the application from source.
 
@@ -535,3 +535,102 @@ When this option is enabled, we can either:
    }
    ```
 
+### Patching the Application
+
+Patching the application occasionally must occur to address incompatibilities with the context of a Linux user space application and that of the unikernel model.
+It can also be used to introduce new features to the application, although this is more rare (although, [here is an example](https://github.com/unikraft/lib-newlib/blob/staging/patches/0010-enable-per-library-allocator-statistics.patch)).
+
+#### Identifying a Change to the Application
+
+Identifying a change to the application which requires a patch is sometimes quite subtle.
+The process usually occurs during [steps 5 and 6 of providing build files](docs/develop/porting/#providing-build-files) of the application or library in question.
+During this process, we are expected to see compile-time and link-time errors from `gcc` as we add new files to the build and make fixes.
+
+The `iperf3` application port to Unikraft has four patches in order to make it work.
+Let's discuss them and what they mean.
+The next section discusses how to create one of these patches.
+
+1. [The first patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0001-Fix-duplicate-import-of-netinet-tcp.h.patch) comes from an error which is thrown when compiling the `iperf_api.c` source file.
+   This file is 3rd to be compiled from the list of complete source files.
+   In this file, we are receiving a duplicate import of `<netinet/tcp.h>`, simply removing this import fixes it, so the patch addresses this issue.
+
+1. [The second patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0002-Disable-SO_SNDBUF-and-SO_RCVBUF-checks.patch) comes as a result of [missing functionality from LwIP](https://github.com/lwip-tcpip/lwip/blob/b0e347158d8db640c6891f9f31f4e6d19dca200b/src/include/lwip/sockets.h#L220).
+   The issue was discovered once the application was fully ported and was able to boot and run.
+   When the initialization sequence was on-going between the client and server of `iperf3`, it would crash during this sequence because LwIP does not support setting this option.
+   A patch was created simply to remove setting this option.
+   (Note: this may not be the most sensible approach)
+
+1. [The third patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0003-Set-the-temp-path-to-the-root.patch) arises from an assumption about the host environment and the difference between Linux user space and a unikernel.
+   With a traditional host OS, we have a filesystem populated with known paths, for example `/tmp`.
+   `iperf3` assumed this path exists, however, in the case of where no filesystem is provided to the unikernel during boot, which should be possible in some cases, the `iperf3` application would crash since `/tmp` does not exist beforehand.
+   The patch solves this by setting the temporary (ramfs) path to `/`.
+   An alternative solution is to make this path at boot.
+
+1. Finally, [the fourth patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0004-Disable-use-of-mmap-and-replace-with-mmalloc-and-fr.patch) is once again to do with missing functionality from Unikraft.
+   In this case, the syscalls [`mmap`](https://linux.die.net/man/2/mmap) and [`munmap`](https://linux.die.net/man/2/munmap) are missing.
+   In this case, `iperf3` used `mmap` simply to statically allocate a region of memory.
+   The trick used here is to simply replace instances of `mmap` with `malloc` and instances of `munmap` with `free`.
+
+   **Note:** At the time writing this tutorial, [`mmap` and `munmap` are being actively worked on to be made available as syscalls in Unikraft](https://github.com/unikraft/unikraft/pull/247).
+
+The above patches represent example use cases where patches may be necessary to fix the application when bringing it to Unikraft.
+The possibilities presented in this tutorial are non-exhaustive, so take care.
+
+The next section discusses in detail how to create a patch for the target
+application or library.
+
+#### Preparing a Patch for the Application
+
+When a change is identified and is to be provided as a patch to the application or library during the compilation, it can be done using the procedure identified in this section.
+Note that providing patches is an unfortunate workaround to the inherent differences between Linux user space applications and libraries and unikernels.
+
+**Note:** When patches are created, they are also version-specific.
+As such, if you update the library or application's code (i.e. by updating, for example, the version number of `LIBIPER3_VERSION`), patches may no longer be apply-able and will then need to be updated accordingly.
+
+To make a patch:
+
+1. First, ensure that the remote origin code has been downloaded to the application's `build/` folder:
+
+   ```bash
+   cd ~/workspace/apps/iperf3
+   kraft fetch
+   ```
+
+1. Once the source files have been downloaded, turn it into a Git repository and save everything to an initial commit, in the case of `iperf3`:
+
+   ```bash
+   cd build/libiperf3/origin/iperf-3.10.1
+   git init
+   git add .
+   git commit -m "Initial commit"
+   ```
+
+   This will allow us to make changes to the source files and save those differences.
+
+1. After making changes, create a Git commit, where you briefly describe the change you made and why.
+   This can be done through a number of successive steps, for example, as a result of having to make several changes to the application.
+
+1. After your changes have been saved to the git log, export them as patches.
+   For example, if you have made one (`1`) patch only, export it like so:
+
+   ```bash
+   git format-patch HEAD~1
+   ```
+
+   This will save a new `.patch` file in the current directory; which should be the origin source files of `iperf3`.
+
+1. The next step is to create a `patches/` folder within the Unikraft port of the library and to move the new `.patch` file into this folder:
+
+   ```bash
+   mkdir ~/workspace/libs/iperf3/patches
+   mv ~/workspace/apps/iperf3/build/libiperf3/origin/iperf-3.10.1/*.patch ~/workspace/libs/iperf3/patches
+   ```
+
+1. To register patches against Unikraft's build tool such that they are applied before the compilation of all source files, simply indicate it in the library's `Makefile.uk`:
+
+   ```Makefile
+   # Add or edit ~/workspace/libs/iperf3/Makefile.uk
+   LIBIPERF3_PATCHDIR = $(LIBIPERF3_BASE)/patches
+   ```
+
+This concludes the necessary steps to port an application to Unikraft "from first principles".


### PR DESCRIPTION
For some reason it seems like the `patching` part of the `porting` section was missed when adding content from [`USoC'21` - basic app porting](https://usoc21.unikraft.org/docs/sessions/08-basic-app-porting/#patching-the-application).

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>