### PR TITLE
github/linter: Fix the end of sentence detection

### DIFF
--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -13,7 +13,7 @@ module.exports = {
 		let outside = true;
 		let count = 0;
 		Array.from(line).forEach((char) => {
-			if ((char == "." || char == "?" || char == "!" || char == ";" || char == ":") && outside) {
+			if ((char == "." || char == "?" || char == "!") && outside) {
 				count++;
 			}
 			if (char == "`") outside = !outside;


### PR DESCRIPTION
The linter detects `:` and `;` as end of sentence, wich `gives multiple sentences per line` errors when not needed.
This commit only interprets `.`, `?` and `!` as end of sentence.

e.g. "List of items: item 1, item 2." is misinterpreted as 2 sentences.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>