### PR TITLE
github/linter: Fix sentence end inside backticks

### DIFF
--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -11,12 +11,14 @@ module.exports = {
       var actual_lines = inline.content.split("\n");
       actual_lines.forEach((line, index, arr) => {
 		let outside = true;
+		let outside_ticks = true;
 		let count = 0;
 		Array.from(line).forEach((char) => {
-			if ((char == "." || char == "?" || char == "!") && outside) {
+			if ((char == "." || char == "?" || char == "!") &&
+				(outside && outside_ticks)) {
 				count++;
 			}
-			if (char == "`") outside = !outside;
+			if (char == "`") outside_ticks = !outside_ticks;
 			if (char == "[") outside = false;
 			if (char == "(") outside = false;
 			if (char == "]") outside = true;


### PR DESCRIPTION
The linter checks for . ? ! outside an escaped sequence. The backticks set the outside variable as `!outside`, while the parentheses set it as true or false, depending of the context. This does not work when backticks are used inside parentheses, making the text between the backticks be interpreted as unescaped.

i.e. "This sentence (having this `.escaped` sequence)." 

gives a linter error, detecting the dot inside backticks as end of sentence.

This commit changes that, using a different variable for checking if we are inside backticks.
Closes: #123 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>