### PR TITLE
github/linter: Remove unnecessary keywords `true` and `false`

### DIFF
--- a/.github/workflows/rules/md101.js
+++ b/.github/workflows/rules/md101.js
@@ -17,8 +17,6 @@ const keywords = [
     new WordPattern("traceroute"),
     new WordPattern("sudo"),
     new WordPattern("(?<!(system |ISRG ))root(?! ca)", { suggestion: "root" }),// match "root", but not "root CA", "MacOS System Root" and "ISRG Root X1"
-    new WordPattern("true"),
-    new WordPattern("false"),
     new WordPattern("jps"),
     new WordPattern("name=value"),
     new WordPattern("key=value"),


### PR DESCRIPTION
The linter checks for keywords and requires them
to be fenced by backticks.
`true` and `false` should not be marked as keywords since they are used a lot in natural language.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>