### PR TITLE
github/linter: Remove the code block language check

### DIFF
--- a/.github/workflows/config/config.json
+++ b/.github/workflows/config/config.json
@@ -4,6 +4,7 @@
 	"MD046": { "style": "fenced" },
 	"MD029": { "style": "one" },
 	"MD014": false,
+	"MD040": false,
 	"line-length": false,
 	"no-hard-tabs": false
 }


### PR DESCRIPTION
We only want to specify the language used (e.g. bash) when adding scripts or lengthier code blocks, not on simple commands, since the highlighting will mess up the commands output.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>