### PR TITLE
hackathons: Replace "-serial stdio" with "-nographic"

### DIFF
--- a/content/en/community/hackathons/sessions/behind-scenes/content/Work-Items_01.-Tutorial---Reminder:-Building-and-Running-Unikraft.md
+++ b/content/en/community/hackathons/sessions/behind-scenes/content/Work-Items_01.-Tutorial---Reminder:-Building-and-Running-Unikraft.md
@@ -100,10 +100,10 @@ We follow the steps:
 1. Load the resulting image in QEMU by using
 
    ```
-   $ sudo qemu-system-x86_64 -kernel ./build/app-helloworld_kvm-x86_64 -serial stdio
+   $ sudo qemu-system-x86_64 -kernel ./build/app-helloworld_kvm-x86_64 -nographic
    ```
 
-Besides `-serial stdio`, no other option is needed to run the `app-helloworld` application.
+Besides `-nographic`, no other option is needed to run the `app-helloworld` application.
 Other, more complex applications, will require more options given to the `qemu-system-x86_64` command.
 
 We have run Unikraft in the emulation mode, with the command from above.
@@ -115,15 +115,15 @@ You can instruct KVM to use your local CPU model, by adding `-cpu host` to the c
 The final command will look like this:
 
 ```
-$ sudo qemu-system-x86_64 -enable-kvm -cpu host -kernel ./build/app-helloworld_kvm-x86_64 -serial stdio
+$ sudo qemu-system-x86_64 -enable-kvm -cpu host -kernel ./build/app-helloworld_kvm-x86_64 -nographic
 ```
 
 While we are here, we can check some differences between emulation and virtualization.
 Record the time needed by each image to run, using `time`, like this:
 
 ```
-$ time sudo qemu-system-x86_64 -kernel ./build/app-helloworld_kvm-x86_64 -serial stdio
-$ time sudo qemu-system-x86_64 -enable-kvm -cpu host -kernel ./build/app-helloworld_kvm-x86_64 -serial stdio
+$ time sudo qemu-system-x86_64 -kernel ./build/app-helloworld_kvm-x86_64 -nographic
+$ time sudo qemu-system-x86_64 -enable-kvm -cpu host -kernel ./build/app-helloworld_kvm-x86_64 -nographic
 ```
 
 Because `helloworld` is a simple application, the **real** running time will be similar.
@@ -149,7 +149,7 @@ $ make
 To run Unikraft, use the following command:
 
 ```
-$ sudo qemu-system-aarch64 -machine virt -cpu cortex-a57 -kernel ./build/app-helloworld_kvm-arm64 -serial stdio
+$ sudo qemu-system-aarch64 -machine virt -cpu cortex-a57 -kernel ./build/app-helloworld_kvm-arm64 -nographic
 ```
 
 Note that now we need to provide a machine and a CPU model to be emulated, as there are no defaults available.

--- a/content/en/community/hackathons/sessions/behind-scenes/content/Work-Items_08.-Tutorial:-Arguments-from-Command-Line.md
+++ b/content/en/community/hackathons/sessions/behind-scenes/content/Work-Items_08.-Tutorial:-Arguments-from-Command-Line.md
@@ -22,7 +22,7 @@ $ make clean
 To send an argument with qemu-system, we use the `-append` option, like this:
 
 ```
-$ qemu-system-x86_64 -kernel build/app-helloworld_kvm-x86_64 -append "console=ttyS0 foo=bar" -serial stdio
+$ qemu-system-x86_64 -kernel build/app-helloworld_kvm-x86_64 -append "console=ttyS0 foo=bar" -nographic
 ```
 
 #### qemu-guest script

--- a/content/en/community/hackathons/sessions/debugging/content/Debugging_Using-GDB.md
+++ b/content/en/community/hackathons/sessions/debugging/content/Debugging_Using-GDB.md
@@ -24,7 +24,7 @@ For KVM, you can start the guest with the kernel image that includes debugging i
 We recommend creating the guest in a paused state (the `-S` option):
 
 ```bash
-$ qemu-system-x86_64 -s -S -cpu host -enable-kvm -m 128 -nodefaults -no-acpi -display none -serial stdio -device isa-debug-exit -kernel build/app-helloworld_kvm-x86_64.dbg -append verbose
+$ qemu-system-x86_64 -s -S -cpu host -enable-kvm -m 128 -nodefaults -no-acpi -display none -nographic -device isa-debug-exit -kernel build/app-helloworld_kvm-x86_64.dbg -append verbose
 ```
 
 Note that the `-s` parameter is shorthand for `-gdb tcp::1234`.

--- a/content/en/community/hackathons/sessions/debugging/work/01-gdb-tutorial/kvm_gdb_debug
+++ b/content/en/community/hackathons/sessions/debugging/work/01-gdb-tutorial/kvm_gdb_debug
@@ -10,7 +10,7 @@ qemu-system-x86_64 -s \
                    -nodefaults \
                    -no-acpi \
                    -display none \
-                   -serial stdio \
+                   -nographic \
                    -device isa-debug-exit \
                    -kernel $path_to_kernel \
                    -append verbose &


### PR DESCRIPTION
Use of "-serial stdio" fails on systems without a graphical user interface; "-nographic" works.