### PR TITLE
docs/usage: Add build and run complex apps doc

### DIFF
--- a/content/en/docs/usage/make_build.md
+++ b/content/en/docs/usage/make_build.md
@@ -461,3 +461,486 @@ oOo oOO| | | | |   (| | | (_) |  _) :_
                  Phoebe 0.10.0~ee2a37cf
 Hello world!
 ```
+
+## Building and Running Complex Applications with Make
+
+Let's say we decide to use already ported applications.
+There are many to choose from, so we will go for [`app-sqlite`](/docs/usage/make_build#app-sqlite-for-x86_64), [`app-redis`](/docs/usage/make_build#app-redis-for-x86_64) or [`app-nginx`](/docs/usage/make_build#app-nginx-for-x86_64).
+This tutorial is here to guide us through the first steps towards successfully launching our (more complex) unikernel.
+For every application, we'll present 2 scenarios: building for `x86_64` and `AArch64`.
+
+### `app-sqlite` for `x86_64`
+
+The first step is to clone our dependencies:
+
+1. [unikraft](https://github.com/unikraft/unikraft)
+
+1. [app-sqlite](https://github.com/unikraft/app-sqlite)
+
+1. [lib-sqlite](https://github.com/unikraft/lib-sqlite), [lib-musl](https://github.com/unikraft/lib-musl)
+
+We should be left with a file hierarchy that looks like this:
+
+```console
+workdir/
+|---apps/
+|      |---app-sqlite/
+|---libs/
+|      |---lib-musl/
+|      |---lib-sqlite/
+|---unikraft/
+```
+
+We must now create a `Makefile` in the `app-sqlite` directory:
+
+```Makefile
+UK_ROOT ?= $(PWD)/../../unikraft
+UK_LIBS ?= $(PWD)/../../libs
+LIBS := $(UK_LIBS)/lib-musl:$(UK_LIBS)/lib-sqlite
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)
+```
+
+We should also create a `Makefile.uk` in the `app-sqlite` directory:
+
+```Makefile
+$(eval $(call addlib,appsqlite))
+```
+
+Now, onto configuring our app:
+
+```console
+$ make menuconfig
+```
+
+1. Choose the `x86` architecture from `Architecture Selection`.
+
+1. Choose the `KVM` platform from `Platform Configuration`.
+
+1. Choose all `Virtio` options from `Platform configuration->KVM guest->Virtio`.
+
+1. Choose the `SQLite`, `musl` and `vfscore` libraries from the `Library Configuration` screen.
+
+1. Under the `vfscore` library, choose the `Default root filesystem` to be `9pfs`.
+
+We'll build our app:
+
+```console
+$ make -j $(ncpus)
+```
+
+We should now create a subdirectory named `fs0/` in the `app-sqlite/` directory.
+Inside it we'll create this `script.sql` script:
+
+```sql
+CREATE TABLE tab (d1 int, d2 text);
+INSERT INTO tab VALUES (random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text)),
+(random(), cast(random() as text));    
+```
+
+The last step is running our app:
+
+```console
+$ sudo qemu-system-x86_64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                          -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                          -kernel "build/app-sqlite_kvm-x86_64" \
+                          -enable-kvm \
+                          -nographic
+```
+
+And testing it:
+
+```console
+Booting from ROM..Powered by
+o.   .o       _ _               __ _
+Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
+oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
+oOo oOO| | | | |   (| | | (_) |  _) :_
+ OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
+      Epimetheus 0.12.0~4c7352c0-custom
+SQLite version 3.30.1 2019-10-10 20:19:45
+Enter ".help" for usage hints.
+Connected to a transient in-memory database.
+Use ".open FILENAME" to reopen on a persistent database.
+sqlite> .read script.sql
+sqlite> select * from tab;
+-7215681294144457603|-7881854117727259003
+2117848104624103428|-1622087965530640476
+-3409481001054928427|-6710007935272102091
+-8864771657867452020|4690809563575391968
+799097535707348776|-9015585007893225196
+-6011599994684870502|5715089397278453373
+-861992803967016915|1583603794332302036
+-5556545375765846451|-8514616268392191775
+6518576960059048853|6826969221610647599
+-2505304097900087778|-1087908404908377458
+sqlite> .exit
+```
+
+{{% alert theme="info" %}}
+**Pro tip**: We usually save the launch command in a script.
+This way, it's easier to type.
+But, if you fancy even more automation, check out [`qemu-guest`](https://github.com/unikraft/kraft/blob/staging/scripts/qemu-guest).
+{{% /alert %}}
+
+### `app-sqlite` for `AArch64`
+
+The process of building `app-sqlite` for `AArch64` is quite similar to the one we've layed out for the `x86_64` architecture.
+The only thing that needs changes is the architecture, which should be switched to `Armv8` in the `Architecture Selection` menu, via `make menuconfig`.
+
+{{% alert theme="info" %}}
+**Note**: Before building our new unikernel (with a different architecture than the one from the previous step), we should do a proper clean, in order to ensure that the application gets compiled for the desired architecture:
+{{% /alert %}}
+
+```console
+$ make properclean
+```
+
+For `AArch64`, the command with which we launch the app is:
+
+```console
+$ sudo qemu-system-aarch64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                           -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                           -kernel "build/app-sqlite_kvm-arm64" \
+                           -machine virt \
+                           -cpu cortex-a57 \
+                           -nographic
+```
+
+### `app-redis` for `x86_64`
+
+The first step is to clone our dependencies:
+
+1. [unikraft](https://github.com/unikraft/unikraft)
+
+1. [app-redis](https://github.com/unikraft/app-redis)
+
+1. [lib-redis](https://github.com/unikraft/lib-redis), [lib-musl](https://github.com/unikraft/lib-musl), [lib-lwip](https://github.com/unikraft/lib-lwip)
+
+We should be left with a file hierarchy that looks like this:
+
+```console
+workdir/
+|---apps/
+|      |---app-redis/
+|---libs/
+|      |---lib-lwip/
+|      |---lib-musl/
+|      |---lib-redis/
+|---unikraft/
+```
+
+We must now create a `Makefile` in the `app-redis` directory:
+
+```Makefile
+UK_ROOT ?= $(PWD)/../../unikraft
+UK_LIBS ?= $(PWD)/../../libs
+LIBS := $(UK_LIBS)/lib-musl:$(UK_LIBS)/lib-lwip:$(UK_LIBS)/lib-redis
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)
+```
+
+We should also create a `Makefile.uk` in the `app-redis` directory:
+
+```Makefile
+$(eval $(call addlib,appredis))
+```
+
+We'll now create a subdirectory named `fs0/` in the `app-redis/` directory, download [this file](https://raw.githubusercontent.com/unikraft/summer-of-code-2021/main/content/en/docs/sessions/04-complex-applications/sol/03-set-up-and-run-redis/redis.conf), a `redis` configuration file, and move it there.
+It will help us design a `redis` server close to our liking.
+
+Configuring our app should go smoothly:
+
+```console
+$ make menuconfig
+```
+
+1. Choose the `x86` architecture from `Architecture Selection`.
+
+1. Choose the `KVM` platform from `Platform Configuration`.
+
+1. Choose the `Redis`, `lwip` and `musl` libraries from `Library Configuration`.
+
+1. In the `Redis` library choose the `Provide main function` option.
+
+1. In the `lwip` library make sure to have `IPv4`, `UDP support`, `TCP support`, `ICMP support`, `DHCP support`, `Socket API` enabled.
+
+1. Under the `vfscore` library, choose the `Default root filesystem` to be `9pfs`.
+
+We'll build our app:
+
+```console
+$ make -j $(ncpus)
+```
+
+Because we'll use networking, we have to set up a bridge:
+
+```console
+$ sudo brctl addbr virbr0
+$ sudo ip a a  172.44.0.1/24 dev virbr0
+$ sudo ip l set dev virbr0 up
+```
+
+We'll check our setup:
+
+```console
+$ ip a s virbr0
+6: virbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
+link/ether 8a:08:a1:69:85:31 brd ff:ff:ff:ff:ff:ff
+inet 172.44.0.1/24 scope global virbr0
+valid_lft forever preferred_lft forever
+inet6 fe80::8808:a1ff:fe69:8531/64 scope link 
+valid_lft forever preferred_lft forever
+```
+
+We are ready to run our app:
+
+```console
+$ sudo qemu-system-x86_64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                          -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                          -netdev bridge,id=en0,br=virbr0 \
+                          -device virtio-net-pci,netdev=en0 \
+                          -kernel "build/app-redis_kvm-x86_64" \
+                          -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 -- /redis.conf" \
+                          -cpu host \
+                          -enable-kvm \
+                          -nographic
+```
+
+We will test our app by using a benchmark.
+Download [this executable](https://github.com/unikraft/summer-of-code-2021/blob/main/content/en/docs/sessions/04-complex-applications/sol/03-set-up-and-run-redis/redis-cli) and run it using this command:
+
+```console
+$ ./redis-cli -h 172.44.0.2 -p 6379
+172.44.0.2:6379> PING
+PONG
+172.44.0.2:6379> exit
+```
+
+Cleaning up our work is always good practice, so let's delete the bridge we've created earlier:
+
+```console
+$ sudo ip l set dev virbr0 down
+$ sudo brctl delbr virbr0
+```
+
+### `app-redis` for `AArch64`
+
+Building `Redis` for the `AArch64` architecture looks very similar to how we did it for `x86_64`.
+The only thing that needs changing is the architecture, which should be switched to `Armv8` in the `Architecture Selection` menu, via `make menuconfig`.
+
+{{% alert theme="info" %}}
+**Note**: Before building our new unikernel (with a different architecture than the one from the previous step), we should do a proper clean, in order to ensure that the application gets compiled for the desired architecture:
+{{% /alert %}}
+
+```console
+$ make properclean
+```
+
+For `AArch64`, the command used to launch the app is:
+
+```console
+$ sudo qemu-system-aarch64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                           -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                           -netdev bridge,id=en0,br=virbr0 \
+                           -device virtio-net-pci,netdev=en0 \
+                           -kernel "build/app-redis_kvm-arm64" \
+                           -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 -- /redis.conf" \
+                           -machine virt \
+                           -cpu cortex-a57 \
+                           -nographic
+```
+
+### `app-nginx` for `x86_64`
+
+The first step is to clone our dependencies:
+
+1. [unikraft](https://github.com/unikraft/unikraft)
+
+1. [app-nginx](https://github.com/unikraft/app-nginx)
+
+1. [lib-nginx](https://github.com/unikraft/lib-nginx), [lib-musl](https://github.com/unikraft/lib-musl), [lib-lwip](https://github.com/unikraft/lib-lwip)
+
+We should be left with a file hierarchy that looks like this:
+
+```console
+workdir/
+|---apps/
+|      |---app-nginx/
+|---libs/
+|      |---lib-lwip/
+|      |---lib-musl/
+|      |---lib-nginx/
+|---unikraft/
+```
+
+We must create a `Makefile` in the `app-nginx` directory:
+
+```Makefile
+UK_ROOT ?= $(PWD)/../../unikraft
+UK_LIBS ?= $(PWD)/../../libs
+LIBS := $(UK_LIBS)/lib-musl:$(UK_LIBS)/lib-lwip:$(UK_LIBS)/lib-nginx
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)
+```
+
+We should also create a `Makefile.uk` in the `app-nginx` directory:
+
+```Makefile
+$(eval $(call addlib,appnginx))
+```
+
+Onto configuring our app:
+
+```console
+$ make menuconfig
+```
+
+1. Choose the `x86` architecture from `Architecture Selection`.
+
+1. Choose the `KVM` platform from `Platform Configuration`.
+
+1. Choose the `uksignal`, `libnginx`, `lwip`, `musl` libraries from `Library Configuration`.
+
+1. In the `libnginx` library, choose the `Provide main function` option.
+
+1. In the `lwip` library, make sure to have `IPv4`, `UDP support`, `TCP support`, `ICMP support`, `DHCP support`, `Socket API` enabled.
+
+1. Under the `vfscore` library, choose the `Default root filesystem` to be `9pfs`.
+
+We'll build our app:
+
+```console
+$ make -j $(ncpus)
+```
+
+Because we'll use networking, we have to set up a bridge:
+
+```console
+$ sudo brctl addbr virbr0
+$ sudo ip a a  172.44.0.1/24 dev virbr0
+$ sudo ip l set dev virbr0 up
+```
+
+We'll check our setup:
+
+```console
+$ ip a s virbr0
+6: virbr0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default qlen 1000
+link/ether 8a:08:a1:69:85:31 brd ff:ff:ff:ff:ff:ff
+inet 172.44.0.1/24 scope global virbr0
+valid_lft forever preferred_lft forever
+inet6 fe80::8808:a1ff:fe69:8531/64 scope link 
+valid_lft forever preferred_lft forever
+```
+
+Running our app is done using this command:
+
+```console
+$ sudo qemu-system-x86_64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                          -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                          -netdev bridge,id=en0,br=virbr0 \
+                          -device virtio-net-pci,netdev=en0 \
+                          -kernel "build/app-nginx_kvm-x86_64" \
+                          -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 --" \
+                          -cpu host \
+                          -enable-kvm \
+                          -nographic
+```
+
+If you're met with this error:
+
+```console
+failed to parse default acl file `/etc/qemu/bridge.conf'
+qemu-system-x86_64: bridge helper failed
+```
+
+make sure to add this to your `/etc/qemu/bridge.conf` file (if it doesn't exist, create it):
+
+```console
+allow all
+```
+
+For testing our app, we'll open a new terminal, or use `tmux`, and give this command to retrive data from the server:
+
+```console
+$ wget 172.44.0.2
+--2021-08-18 16:47:38--  http://172.44.0.2/
+--2022-07-19 21:17:17--  http://172.44.0.2/
+Connecting to 172.44.0.2:80... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 180 [text/html]
+Saving to: ‘index.html’
+
+2022-07-19 21:17:17 (14,7 MB/s) - ‘index.html’ saved [180/180]
+```
+
+```console
+$ cat index.html 
+<!DOCTYPE html>
+<html>
+<head>
+<title>Hello, world!</title>
+</head>
+<body>
+<h1>Hello, world!</h1>
+<p>Powered by <a href="http://unikraft.org">Unikraft</a>.</p>
+</body>
+</html>
+```
+
+Don't forget to clean up our work: let's delete the bridge we've created earlier:
+
+```console
+$ sudo ip l set dev virbr0 down
+$ sudo brctl delbr virbr0
+```
+
+### `app-nginx` for `AArch64`
+
+Just like we've stated for `SQLite` and `Redis`, for `AArch64` the build steps follow the tutorial for `x86_64`.
+The only thing that needs changes is the architecture, which should be switched to `Armv8` in the `Architecture Selection` menu, via `make menuconfig`.
+
+{{% alert theme="info" %}}
+**Note**: Before building our new unikernel (with a different architecture than the one from the previous step), we should do a proper clean, in order to ensure that the application gets compiled for the desired architecture:
+{{% /alert %}}
+
+```console
+$ make properclean
+```
+
+Let's launch the unikernel:
+
+```console
+$ sudo qemu-system-aarch64 -fsdev local,id=myid,path=$(pwd)/fs0,security_model=none \
+                           -device virtio-9p-pci,fsdev=myid,mount_tag=rootfs,disable-modern=on,disable-legacy=off \
+                           -netdev bridge,id=en0,br=virbr0 \
+                           -device virtio-net-pci,netdev=en0 \
+                           -kernel "build/app-nginx_kvm-arm64" \
+                           -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 --" \
+                           -machine virt \
+                           -cpu cortex-a57 \
+                           -nographic
+```
+
+With this last command, our tutorial ends, it was a long ride but the results should be rewarding enough.


### PR DESCRIPTION
This PR adds documentation for building and running complex applications on `x86` and `AArch64`.

It goes into detail regarding configuration steps and manual launch commands for the make build system.
Depends on having these PRs merged:

* [core Unikraft virtio PR](https://github.com/unikraft/unikraft/pull/519)
* [`newlib` PR](https://github.com/unikraft/lib-newlib/pull/21)

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>