### PR TITLE
layout: Change the default website thumbnail

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="thumbnail" content="assets/imgs/unikraft.svg">
     <title>{{ block "title" . }}{{ .Title }} – {{ .Site.Title }}{{ end }}</title>
     {{ partial "head/scripts" . }}
     {{ partial "head/styles" . }}


### PR DESCRIPTION
Since there is not a `thumbnail` field in the
main page header, a default one is loaded from
an image on the main page, but it's not the
Unikraft logo.
This commit adds the Unikraft logo as a thumbnail
for all the pages in the website.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>