### PR TITLE
Update community/contacts

### DIFF
--- a/content/en/community/contacts.md
+++ b/content/en/community/contacts.md
@@ -11,12 +11,13 @@ The fastest way to get in contact with members of the community is to engage wit
 
 Primary contacts of the open-source project include:
 
-| Name              | Email                       | Affiliation                         |
-| ----------------- | --------------------------- | ----------------------------------- |
-| Simon Kuenzer     | simon.kuenzer@neclab.eu     | NEC Laboratories Europe GmbH        |
-| Răzvan Deaconescu | razvan.deaconescu@cs.pub.ro | University POLITEHNICA of Bucharest |
-| Alexander Jung    | a.jung@lancs.ac.uk          | Lancaster Universitiy               |
-| Marc Rittinghaus  | marc.rittinghaus@kit.edu    | Karlsruhe Institute of Technology   |
+| Name              | Email                 | Affiliation      |
+| ----------------- | --------------------- | ---------------- |
+| Simon Kuenzer     | simon@unikraft.org    | Unikraft GmbH    |
+| Răzvan Deaconescu | razvand@unikraft.org  | Unikraft GmbH    |
+| Alexander Jung    | alex@unikraft.org     | Unikraft GmbH    |
+| Marc Rittinghaus  | marc@unikraft.org     | Unikraft GmbH    |
+| Felipe Huici      | felipe@unikraft.org   | Unikraft GmbH    |
 
 For general enquiries and open discussions, please consult our open mailing lists:
 


### PR DESCRIPTION
This commit updates the primary contacts table of the community page to reflect the current mail addresses and affiliation of the contacts. The commit only puts core company members in for now to restrict the number of contacts also with regard to future growth of the company. Nevertheless, additional contacts may be added later if needed (also from the community).

Signed-off-by: Marc Rittinghaus <marc.rittinghaus@unikraft.io>