### PR TITLE
github/linter: Remove `.png` keyword

### DIFF
--- a/.github/workflows/rules/md101.js
+++ b/.github/workflows/rules/md101.js
@@ -30,7 +30,6 @@ const keywords = [
     new WordPattern("stderr"),
     new WordPattern("SIGTERM"),
     new WordPattern("NaN"),
-    new WordPattern(".png", { noWordBoundary: true }),
     new WordPattern(".xml", { noWordBoundary: true }),
     new WordPattern(".jar", { noWordBoundary: true }),
     new WordPattern(".gz", { noWordBoundary: true }),


### PR DESCRIPTION
When adding images in `Hugo`, the linter picks them up as keywords and requires them to be inside backticks.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>