### PR TITLE
github/linter: Ignore md104 rule when inside shortcodes

### DIFF
--- a/.github/workflows/rules/md104.js
+++ b/.github/workflows/rules/md104.js
@@ -9,13 +9,16 @@ module.exports = {
       return token.type === "inline";
     })) {
       var actual_lines = inline.content.split("\n");
+      var hugo_shortcode = false;
       actual_lines.forEach((line, index, arr) => {
+		if (line.startsWith("{{"))
+		      hugo_shortcode = true;
 		let outside = true;
 		let outside_ticks = true;
 		let count = 0;
 		Array.from(line).forEach((char) => {
 			if ((char == "." || char == "?" || char == "!") &&
-				(outside && outside_ticks)) {
+				(outside && outside_ticks && !hugo_shortcode)) {
 				count++;
 			}
 			if (char == "`") outside_ticks = !outside_ticks;
@@ -24,6 +27,8 @@ module.exports = {
 			if (char == "]") outside = true;
 			if (char == ")") outside = true;
 		});
+		if (line.endsWith("}}"))
+		      hugo_shortcode = false;
         if (count > 1) {
           onError({
             lineNumber: inline.lineNumber + index,


### PR DESCRIPTION
When using shortcodes, we should ignore the "one line per sentence and
one sentence per line" linter rule.

This however requires the hugo shortcodes to extend on more than one line.
More precisely, the line that contains the closing `}}` marks is not considered inside a hugo shortcode.
For example:
```md
{{ [...] some. text! with? many: punctuation. marks. [...] }}
```
will still fail, but
```md
{{ [...]
[...] some. text! with? many: punctuation. marks. [...]
[...] }}
```
will pass the tests.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>