### PR TITLE
Add `CONTRIBUTING.md` file referencing the website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+Contributing to Unikraft Documentation
+======================================
+
+First of all, welcome to Unikraft!
+We are happy that you are interested in contributing to this project.
+New features, bugfixes, improvements, maintenance and everything in between as contributions are welcome!
+
+The Unikraft project is an open source project and encourages the fostering open collaboration.
+For details on how to contribute to the Unikraft documentation, [please read the contribution guidelines](https://unikraft.org/docs/contributing/docs) located on the [Documentation site](https://unikraft.org/docs).


### PR DESCRIPTION
The contributing file is roughly copied from the [main `Unikraft` repo](https://github.com/unikraft/unikraft/blob/staging/CONTRIBUTING.md).

Closes: #167 

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>