### PR TITLE
Fix kraft via pip installation step

### DIFF
--- a/content/en/docs/usage/install.md
+++ b/content/en/docs/usage/install.md
@@ -154,7 +154,7 @@ too by specifying the install location of the repository from
 [GitHub](https://github.com/unikraft/kraft.git):
 
 ```console
-pip3 install https://github.com/unikraft/kraft.git@stable
+pip3 install git+https://github.com/unikraft/kraft.git
 ```
 
 ### Install to hack


### PR DESCRIPTION
The current step does not work, the new one does.

See https://pip.pypa.io/en/stable/topics/vcs-support/

```
$ pip3 install https://github.com/unikraft/kraft.git@stable
Collecting https://github.com/unikraft/kraft.git@stable
  HTTP error 404 while getting https://github.com/unikraft/kraft.git@stable
  Could not install requirement https://github.com/unikraft/kraft.git@stable because of error 404 Client Error: Not Found for url: https://github.com/unikraft/kraft.git@stable
Could not install requirement https://github.com/unikraft/kraft.git@stable because of HTTP error 404 Client Error: Not Found for url: https://github.com/unikraft/kraft.git@stable for URL https://github.com/unikraft/kraft.git@stable
```