### PR TITLE
.github: Add configuration file for textlint

### DIFF
--- a/.github/workflows/.textlintrc
+++ b/.github/workflows/.textlintrc
@@ -1,0 +1,12 @@
+{
+  "rules": {
+    "terminology": {
+      // Load default terms (see terms.jsonc in the repository)
+      "defaultTerms": true,
+      "exclude": [
+        "web[- ]?site(s)?",
+        "build system(s)?"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Accept "website" and "build system" and do not issue errors to use "site" and "build tool".

You can test by installing [`textlint`]() and [`textlint-rule-methodology`]():

```console
$ npm install textlint
$ npm install textlint-rule-terminology
```

and creating a `test.md` file:

```console
$ echo 'website build system repo' > test.md
```

then running:

```console
$ npx textlint --config .github/workflows/.textlintrc test.md 
```

Only the `repo` term should issue an error. `website` and `build system` will not issue an error.