### PR TITLE
docs: fix typos in the en/docs/contributing

### DIFF
--- a/content/en/docs/contributing/docs.md
+++ b/content/en/docs/contributing/docs.md
@@ -7,7 +7,7 @@ weight: 507
 
 ## Documentation
 
-As with the other parts of Unikraft, we welcome contributios to the [documentation repository](https://github.com/unikraft/docs).
+As with the other parts of Unikraft, we welcome contributions to the [documentation repository](https://github.com/unikraft/docs).
 Documentation is written using [GitHub Markdown](https://github.github.com/gfm/) and is built using [Hugo](https://gohugo.io/commands/hugo_server/).
 
 Please use pull requests (PRs) to submit corrections and improvements to documentation.
@@ -16,7 +16,7 @@ You can add entire sections if you think a topic is missing or update existing o
 You can also open up an issue to signal a problem or a missing part in the documentation that you request someone to fix.
 
 We use English as a documentation language.
-Please proof read your text before submitting a pull request.
+Please proofread your text before submitting a pull request.
 
 Write each sentence on a new line.
 This way, changing one sentence only affects one line in the source code.


### PR DESCRIPTION
Signed-off-by: Radu Nichita <radunichita99@gmail.com>