### PR TITLE
docs/testing: Add more ways of running checkpatch

### DIFF
--- a/content/en/docs/contributing/testing.md
+++ b/content/en/docs/contributing/testing.md
@@ -19,7 +19,7 @@ During development, disable `CONFIG_OPTIMIZE_DEADELIM` (Found in themenuconfig v
 To support you in checking your coding style, we provide a tailored version of the Linux kernel's `checkpatch.pl` script in [`support/scripts/checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl).
 You should run this from the root of the Unikraft repository because it contains a [`.checkpatch.conf`](https://github.com/unikraft/unikraft/blob/staging/.checkpatch.conf) file which disables some tests that we consider irrelevant for Unikraft.
 
-Please run this script on all commit you are about to submit.
+Please run this script on all commits you are about to submit.
 To do this, create a patch file for each commit on your working branch by running `git format-patch`.
 For example, to create patch files for the last 5 commits:
 
@@ -27,5 +27,33 @@ For example, to create patch files for the last 5 commits:
 $ git format-patch HEAD~5
 $ ./support/scripts/checkpatch.pl ./000*
 ```
+
+You can also run the `checkpatch` on one or multiple files before committing by using the `-f` option.
+Furthermore, some errors can be automatically solved by using the `--fix-inplace` option:
+
+```console
+$ ./support/scripts/checkpatch.pl --no-tree -f --fix-inplace <path/to/the/file>
+```
+
+For example, if you have some changes in the `lib/vfscore/vfs.h`, you can check and fix potential coding style issue with:
+
+```console
+$ ./support/scripts/checkpatch.pl --no-tree --fix-inplace -f lib/vfscore/vfs.h
+ERROR: "foo*bar" should be "foo *bar"
+#576: FILE: lib/vfscore/vfs.h:576:
++int	sys_chmod(const char*path, mode_t mode);
+
+total: 1 errors, 0 warnings, 828 lines checked
+[...]
+
+$ ./support/scripts/checkpatch.pl --no-tree --fix-inplace -f lib/vfscore/vfs.h
+total: 0 errors, 0 warnings, 828 lines checked
+
+lib/vfscore/vfs.h has no obvious style problems and is ready for submission.
+```
+
+{{< alert theme="info" >}}
+Note that not all the coding style errors can be solved automatically and some of them should be addressed by hand.
+{{< /alert >}}
 
 Please attempt fixes for all errors and warnings; if you decide to ignore some, be prepared to have a good reason for each warning and error during the [review process](/docs/contributing/review-process).


### PR DESCRIPTION
This PR adds a new way of running the `checkpatch.pl` script. Currently, the documentation mentioned running the coding-style checker only for a specific number of commits rather than for the file itself before committing. 

Closes #180.

Signed-off-by: Radu Nichita [radunichita99@gmail.com](mailto:radunichita99@gmail.com)