### PR TITLE
SECURITY.md: add security disclosure document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+Unikraft is still in development phase; [not all security features have been
+implemented](https://unikraft.org/docs/features/security/). Nevertheless, the
+Unikraft project welcomes security vulnerability reports.
+
+## Reporting Security Vulnerabilities
+
+If you have found a security vulnerability in Unikraft, we invite you to send
+an e-mail to security@unikraft.org. Please do not disclose the vulnerability
+before coordinating with us; we will work together to determine a suitable
+disclosure timeframe.
+
+## Responsible Disclosure
+
+We follow the principles of responsible disclosure. This means:
+
+- Users first: we will work together with you to establish a suitable disclosure
+  timeframe for the vulnerability. We will treat security reports as a priority.
+- Transparency: after at most 90 days, security vulnerabilities will be
+  transparently published to the community on our [security disclosure page](TODO LINK).
+
+## Security Disclosure Q&A
+
+### Should I request a CVE number for my vulnerability?
+
+Please do not request a CVE number without coordinating with us. In general we
+do not request CVE numbers *yet* as Unikraft is still in early development
+phases when it comes to security and defensive features.
+
+### Does the Unikraft project award bounties?
+
+As a community-driven project, we do not award bounties for vulnerability
+reports; however we will mention your name in our [security disclosure page](TODO LINK).
+
+### Where are security fixes released?
+
+We release security fixes to the Unikraft staging branch, which regularly
+transitions to stable. As Unikraft is still in development stages, we do not
+backport security fixes to older Unikraft releases. However, we maintain a list
+of disclosed vulnerabilities along with corresponding fix(es) on our
+[security disclosure page](TODO LINK).


### PR DESCRIPTION
This is a draft of the security disclosure document.

A few items that we need to discuss:

- Before merging this, we should create the security disclosure page mentioned here.
- Do we mention sending swag in this document? Let's take a decision.
- Is the name and location of this file correct? Do we want to have it here or in the main tree? Do we want to have a file in the main tree that points to this?

Signed-off-by: Hugo Lefeuvre <hugo.lefeuvre@manchester.ac.uk>