### PR TITLE
Add landing page for Amsterdam'23 hackathon

### DIFF
--- a/content/en/community/hackathons/2023-04-amsterdam/_index.md
+++ b/content/en/community/hackathons/2023-04-amsterdam/_index.md
@@ -1,0 +1,60 @@
+---
+title: Amsteradam 2023
+date: 2023-03-10T05:40:00+02:00
+draft: false
+collapsible: true
+description: Information on the Amsterdam Unikraft Hackathon, April 15-16, 2023
+---
+
+## Amsterdam Unikraft Hackathon
+
+Unikraft, [Vrije Universiteit Amsterdam (VUA)](https://vu.nl/en) and [VUSec](https://www.vusec.net/) come together to organize the **Unikraft Amsterdam Hackathon** to be held on Saturday and Sunday, April 15-16, 2023.
+
+The hackathon will take place as an in-person event at [the "NU" building in the VUA campus](https://www.vusec.net/directions/).
+The full address is: [NU building, De Boelelaan 1111, 1081 HV, Amsterdam, The Netherlands](https://goo.gl/maps/vbpiJRzbEvcL92bBA).
+
+Support information and discussions will take place on [Discord](http://bit.ly/UnikraftDiscord) on the `#hack-amsterdam23` channel.
+
+### Registration
+
+To take part in the hackathon please fill this [registration form](https://forms.gle/hCm2Qbg7mfa6pkrLA) by **Sunday, April 9, 2023, 11pm CET**.
+
+Please bring your own laptop.
+It's best if you have a native Linux installed on your laptop.
+For any situation, we will have virtual machines ready, to be able to get hacking quickly and easily.
+
+### People
+
+The hosts of the hackathon are:
+
+* [Cristiano Giuffrida](https://www.vusec.net/people/cristiano-giuffrida/)
+
+As part of the Unikraft community, [Răzvan Deaconescu](https://github.com/razvand/) will be on-site, with other community members providing support online, on Discord.
+
+### Schedule
+
+#### Saturday, April 15, 2023
+
+| Time (CET)    | Session                                                              | Presenter          |
+| ------------- | -------------------------------------------------------------------- | ------------------ |
+| 10:00 - 10:15 | Overview of Unikernels and Unikraft                                  |                    |
+| 10:15 - 11:15 | Introduction to Unikraft: Building and Running Standard Applications |                    |
+| 11:15 - 11:30 | Break                                                                |                    |
+| 11:30 - 12:45 | Unikraft Internals: Building, Configuring, Using Libraries           |                    |
+| 12:45 - 14:00 | Lunch                                                                |                    |
+| 14:00 - 15:00 | Running (Complex) Applications in Unikraft                           |                    |
+| 15:00 - 16:00 | Porting Applications to Unikraft                                     |                    |
+| 16:00 - 16:15 | Break                                                                |                    |
+| 16:15 - 17:45 | Guest Talks                                                          |                    |
+
+#### Sunday, April 16, 2023
+
+| Time (CET)    | Session                                             |
+| ------------- | --------------------------------------------------- |
+| 10:00 - 10:15 | Overview of Hackathon Challenges                    |
+| 10:15 - 11:30 | Work on Hackathon Challenges                        |
+| 11:30 - 11:45 | Break                                               |
+| 11:45 - 12:45 | Work on Hackathon Challenges                        |
+| 12:45 - 14:00 | Lunch                                               |
+| 14:00 - 17:30 | Work on Hackathon Challenges                        |
+| 17:30 - 17:45 | Results, Final Remarks                              |


### PR DESCRIPTION
Hackathon is host by VUA / VUSec. It will take place on Saturday and Sunday, April 15-16, 2023.