### PR TITLE
hack-amsterdam23: Fix typo in title

### DIFF
--- a/content/en/community/hackathons/2023-04-amsterdam/_index.md
+++ b/content/en/community/hackathons/2023-04-amsterdam/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Amsteradam 2023
+title: Amsterdam 2023
 date: 2023-03-10T05:40:00+02:00
 draft: false
 collapsible: true


### PR DESCRIPTION
Use "Amsterdam" instead of "Amsteradam".