### PR TITLE
`hack/athens2`3: Simplify binary compatibility session

### DIFF
--- a/content/en/community/hackathons/2023-03-athens/bincompat/index.md
+++ b/content/en/community/hackathons/2023-03-athens/bincompat/index.md
@@ -9,17 +9,9 @@ summary: "Run Linux ELF binaries on top of Unikraft using the binary compatibili
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/intro.md" markdown="true" >}}
 
-### 01. System Calls
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Reminders_System-Calls.md" markdown="true" >}}
-
-### 02. The Process of Loading and Running an Application with Binary Compatibility
+### 01. The Process of Loading and Running an Application with Binary Compatibility
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Overview_01.-The-Process-of-Loading-and-Running-an-Application-with-Binary-Compatibility.md" markdown="true" >}}
-
-### 03. Unikraft Syscall Shim
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Overview_02.-Unikraft-Syscall-Shim.md" markdown="true" >}}
 
 ## Summary
 
@@ -43,19 +35,7 @@ summary: "Run Linux ELF binaries on top of Unikraft using the binary compatibili
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_02.-Debug-Run.md" markdown="true" >}}
 
-### 03. Build app-elfloader from Existing Config
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_03.-Build-app-elfloader-from-Existing-Config.md" markdown="true" >}}
-
-### 04. Doing it From Scratch
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_04.-Doing-it-From-Scratch.md" markdown="true" >}}
-
-### 05. Build with Debugging
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_05.-Build-with-Debugging.md" markdown="true" >}}
-
-### 06. Create your Own Application
+### 03. Create your Own Application
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_06.-Create-your-Own-Application.md" markdown="true" >}}
 


### PR DESCRIPTION
Only use the pre-built `app-elfloader`. Remove tasks that involve building `app-elfloader`.