### PR TITLE
sessions/bincompat: Update contents to use unikraft-upb/scripts

### DIFF
--- a/content/en/community/hackathons/2023-04-amsterdam/bincompat/index.md
+++ b/content/en/community/hackathons/2023-04-amsterdam/bincompat/index.md
@@ -19,10 +19,6 @@ summary: "Run Linux ELF binaries on top of Unikraft using the binary compatibili
 
 ## Work Items
 
-### Support Files
-
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_Support-Files.md" markdown="true" >}}
-
 ### 00. Setup
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_00.-Setup.md" markdown="true" >}}
@@ -31,11 +27,15 @@ summary: "Run Linux ELF binaries on top of Unikraft using the binary compatibili
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_01.-Run-Binary-Applications.md" markdown="true" >}}
 
-### 02. Debug Run
+### 02. Build `app-elfloader`
 
-{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_02.-Debug-Run.md" markdown="true" >}}
+{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_02.-Build-app-elfloader.md" markdown="true" >}}
 
-### 03. Create your Own Application
+### 03. Doing It Manually
+
+{{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_03.-Doing-It-Manually.md" markdown="true" >}}
+
+### 04. Create your Own Application
 
 {{< readfile file="/community/hackathons/sessions/bincompat/content/Work-Items_06.-Create-your-Own-Application.md" markdown="true" >}}
 

--- a/content/en/community/hackathons/sessions/bincompat/content/Overview_01.-The-Process-of-Loading-and-Running-an-Application-with-Binary-Compatibility.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Overview_01.-The-Process-of-Loading-and-Running-an-Application-with-Binary-Compatibility.md
@@ -1,60 +1,11 @@
 For Unikraft to achieve binary compatibility there are two main objectives that need to be met:
 
-1. The ability to pass the ELF binary to Unikraft at boot time.
+1. The ability to pass the Linux ELF binary to Unikraft at boot time.
 1. The ability to load the passed ELF binary into memory and jump to its entry point.
 
-For the first point we decided to use the initial ramdisk in order to pass the binary to the unikernel.
-With `qemu-guest`, in order to pass an initial ramdisk to a virtual machine you have to use the `-initrd` option.
-As an example, if we have a `helloworld` binary, we can pass it to the unikernel with the following command:
-
-```console
-sudo qemu-guest -kernel build/unikernel_image -i helloworld_binary
-```
-
-After the unikernel reads the binary the next step is to load it into memory.
 The dominant format for executables is the *Executable and Linkable File* format (ELF), so, in order to run executables we need an ELF loader.
 The job of the ELF Loader is to load the executable into the main memory.
 It does so by reading the program headers located in the ELF formatted executable and acting accordingly.
-For example, you can see the program headers of a program by running `readelf -l binary`:
-
-```console
-$ readelf -l helloworld_binary
-
-Elf file type is DYN (Shared object file)
-Entry point 0x8940
-There are 8 program headers, starting at offset 64
-
-Program Headers:
-  Type           Offset             VirtAddr           PhysAddr
-                 FileSiz            MemSiz              Flags  Align
-  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
-                 0x00000000000c013e 0x00000000000c013e  R E    0x200000
-  LOAD           0x00000000000c0e40 0x00000000002c0e40 0x00000000002c0e40
-                 0x00000000000053b8 0x0000000000006aa0  RW     0x200000
-  DYNAMIC        0x00000000000c3c18 0x00000000002c3c18 0x00000000002c3c18
-                 0x00000000000001b0 0x00000000000001b0  RW     0x8
-  NOTE           0x0000000000000200 0x0000000000000200 0x0000000000000200
-                 0x0000000000000044 0x0000000000000044  R      0x4
-  TLS            0x00000000000c0e40 0x00000000002c0e40 0x00000000002c0e40
-                 0x0000000000000020 0x0000000000000060  R      0x8
-  GNU_EH_FRAME   0x00000000000b3d00 0x00000000000b3d00 0x00000000000b3d00
-                 0x0000000000001afc 0x0000000000001afc  R      0x4
-  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
-                 0x0000000000000000 0x0000000000000000  RW     0x10
-  GNU_RELRO      0x00000000000c0e40 0x00000000002c0e40 0x00000000002c0e40
-                 0x00000000000031c0 0x00000000000031c0  R      0x1
-
- Section to Segment mapping:
-  Segment Sections...
-   00     .note.ABI-tag .note.gnu.build-id .gnu.hash .dynsym .dynstr .rela.dyn .rela.plt .init .plt .plt.got .text __libc_freeres_fn __libc_thread_freeres_fn .fini .rodata .stapsdt.base .eh_frame_hdr .eh_frame .gcc_except_table
-   01     .tdata .init_array .fini_array .data.rel.ro .dynamic .got .data __libc_subfreeres __libc_IO_vtables __libc_atexit __libc_thread_subfreeres .bss __libc_freeres_ptrs
-   02     .dynamic
-   03     .note.ABI-tag .note.gnu.build-id
-   04     .tdata .tbss
-   05     .eh_frame_hdr
-   06
-   07     .tdata .init_array .fini_array .data.rel.ro .dynamic .got
-```
 
 As an overview of the whole process, when we want to run an application on Unikraft using binary compatibility, the first step is to pass the executable file to the unikernel as an initial ram disk.
 Once the unikernel gets the executable, it reads the executable segments and loads them accordingly.
@@ -62,7 +13,12 @@ After the program is loaded, the last step is to jump to its entry point and sta
 
 The unikernel image is the [`app-elfloader` application](https://github.com/unikraft/app-elfloader).
 This application parses the ELF file and then loads it accordingly.
+It's a custom application developed for Unikraft.
 
-We will work only with `static-pie` executables (all the libraries are part of the executables and the code is position-independent).
-A position independent executable is a binary that can run correctly independent of the address at which it was loaded.
-So, for building executables, we currently need to use `-static-pie` compiler / linker option, available in GCC since version 8.
+We require PIE (*position-independent executable*) ELFs.
+This is fine, as default Linux executables are built as PIE.
+
+We have collected PIE executables in:
+
+- the [`dynamic-apps`](https://github.com/unikraft/dynamic-apps) repository - storing dynamically-linked executables
+- the [`static-pie-apps`](https://github.com/unikraft/static-pie-apps) repository - storing statically-linked executables

--- a/content/en/community/hackathons/sessions/bincompat/content/Work-Items_00.-Setup.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Work-Items_00.-Setup.md
@@ -1,34 +1,23 @@
-For the practical work we will need the following prerequisites:
-
-* **gcc version >= 8** - installation guide [here](https://linuxize.com/post/how-to-install-gcc-compiler-on-ubuntu-18-04/)
-
-* **the elfloader application** - this is the implementation of our loader which is build like a normal Unikraft application.
-  You can clone the [ELF Loader repository](https://github.com/unikraft/app-elfloader/).
-  This cloned repo should go into the `apps` folder in your Unikraft directory structure.
-
-* **lwip, zydis, libelf libs** - we have to clone all the repos coresponding to the previously mentioned libraries into the libs folder.
-    * [lwip](https://github.com/unikraft/lib-lwip)
-    * [zydis](https://github.com/unikraft/lib-zydis)
-    * [libelf](https://github.com/unikraft/lib-libelf)
-
-* **unikraft** - the [Unikraft core repository](https://github.com/unikraft/unikraft) must also be cloned.
-
-* **test scripts** - the [run-app-elfloader repository](https://github.com/unikraft/run-app-elfloader) with the scripts to run the resulting Unikraft image with binary applications
-    * see the [README file](https://github.com/unikraft/run-app-elfloader/blob/master/README.md#run-app-elf-loader) for detailed information
-
-* **test applications** - the [static-pie-apps repository](https://github.com/unikraft/static-pie-apps) stores pre-compiled `static-pie` ELF files
-
-In the end you would have the following setup:
+To easily setup, build and run Linux ELFs with [`app-elfloader`](https://github.com/unikraft/app-elfloader), best way is to use [the `scripts` repository](https://github.com/unikraft-upb/scripts).
+Clone [the `scripts` repository](https://github.com/unikraft-upb/scripts) on your machine to get started.
 
 ```console
-.
-|-- apps/
-|   |-- app-elfloader/
-|   |-- run-app-elfloader/
-|   `-- static-pie-apps/
-|-- libs/
-|   |-- libelf/
-|   |-- lwip/
-|   `-- zydis/
-`-- unikraft/
+$ git clone https://github.com/unikraft-upb/scripts
+
+$ cd scripts/
+
+$ cd make-based/app-elfloader/
+
+$ ./do.sh run
+'run' command requires target application as argument
+Target applications: helloworld_static server_static helloworld_go_static server_go_static helloworld_cpp_static helloworld_rust_static_musl helloworld_rust_static_gnu nginx_static redis_static sqlite3 bc_static gzip_static helloworld server helloworld_go server_go helloworld_cpp helloworld_rust nginx redis sqlite3 bc gzip
+
+$ ./do.sh run helloworld
+[...]                       # many messages
+
+$ ./do.sh run sqlite3
+[...]                       # many messages
 ```
+
+The last commands run the dynamic versions of `helloworld` and `sqlite3` applications, the ones in [the `dynamic-apps` repository](https://github.com/unikraft/dynamic-apps).
+There is a lot of output because, by default, a pre-build version of [`app-elfloader`](https://github.com/unikraft/app-elfloader) is being used, with debugging enabled.

--- a/content/en/community/hackathons/sessions/bincompat/content/Work-Items_01.-Run-Binary-Applications.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Work-Items_01.-Run-Binary-Applications.md
@@ -1,5 +1,7 @@
-We want to test the `run-app-elfloader/` setup together with applications in `static-pie-apps/` repository.
+Run as many executables as possible from the list of applications listed by the command:
 
-Run as many executables as possible from the `static-pie-apps/` repository.
-
-See the instructions in the [README](https://github.com/unikraft/run-app-elfloader/blob/master/README.md) and run `redis-server` and `sqlite3` static PIE executables.
+```console
+$ ./do.sh run
+'run' command requires target application as argument
+Target applications: helloworld_static server_static helloworld_go_static server_go_static helloworld_cpp_static helloworld_rust_static_musl helloworld_rust_static_gnu nginx_static redis_static sqlite3 bc_static gzip_static helloworld server helloworld_go server_go helloworld_cpp helloworld_rust nginx redis sqlite3 bc gzip
+```

--- a/content/en/community/hackathons/sessions/bincompat/content/Work-Items_02.-Build-app-elfloader.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Work-Items_02.-Build-app-elfloader.md
@@ -1,0 +1,40 @@
+Using `do.sh run` we ran the prebuilt images from [the `run-app-elfloader` repository](https://github.com/unikraft/run-app-elfloader).
+Let's now also build `app-elfloader`.
+
+Run the following commands:
+
+```console
+$ ./do.sh clean
+
+$ ./do.sh setup
+
+$ ./do.sh build
+
+$ ./do.sh run_built ...
+```
+
+In the last command, replace `...` with the name of the application you need to run.
+
+If you want to remove all the pesky debugging information, use `setup_plain`, such as the commands below:
+
+```console
+$ ./do.sh clean
+
+$ ./do.sh setup_plain
+
+$ ./do.sh build
+
+$ ./do.sh run_built ...
+```
+
+If, on the other side, you want to have more debugging information, use `setup_debug`, such as the commands below:
+
+```console
+$ ./do.sh clean
+
+$ ./do.sh setup_debug
+
+$ ./do.sh build
+
+$ ./do.sh run_built ...
+```

--- a/content/en/community/hackathons/sessions/bincompat/content/Work-Items_03.-Doing-It-Manually.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Work-Items_03.-Doing-It-Manually.md
@@ -1,0 +1,13 @@
+Let's see what happens behind the scenes.
+Enter the `run-app-elfloader/` directory:
+
+```console
+.../scripts/make-based/app-elfloader$ cd ../../workdir/apps/run-app-elfloader/
+
+.../workdir/apps/run-app-elfloader$ ls
+app-elfloader_kvm-x86_64*             app-elfloader_kvm-x86_64_full-debug.dbg*  debug.sh*  out/       rootfs/      run.sh*
+app-elfloader_kvm-x86_64_full-debug*  app-elfloader_kvm-x86_64_plain*           defaults   README.md  run_app.sh*  utils/
+```
+
+Follow the instructions in [the `README.md` file](https://github.com/unikraft/run-app-elfloader/blob/master/README.md) to run as many applications as possible directly.
+That means through the use of the `run_app.sh` and `run.sh` scripts.

--- a/content/en/community/hackathons/sessions/bincompat/content/Work-Items_06.-Create-your-Own-Application.md
+++ b/content/en/community/hackathons/sessions/bincompat/content/Work-Items_06.-Create-your-Own-Application.md
@@ -1,4 +1,3 @@
-Create your own application as a static PIE ELF file.
-Use a programming language that provides static PIE ELF files.
+Create your own application or get an existing application, build it and run it in binary compatability mode.
 
-Run it with the `app-elfloader`.
+See the existing examples in [the `dynamic-apps` repository](https://github.com/unikraft/dynamic-apps) or [the `static-pie-apps` repository](https://github.com/unikraft/static-pie-apps).


### PR DESCRIPTION
Update to the most recent version of `app-elfloader`, `run-app-elfloader`. Use `scripts` repository in `unikraft-upb`.