### PR TITLE
.github/workflows: Remove top level heading check

### DIFF
--- a/.github/workflows/config/config.json
+++ b/.github/workflows/config/config.json
@@ -6,5 +6,6 @@
 	"MD014": false,
 	"MD033": false,
 	"MD034": false,
+	"MD041": false,
 	"line-length": false
 }


### PR DESCRIPTION
The linter checks if the first line in the file is a top-level heading.
This does not work with markdown files that are included in other files, not used as such (e.g. files under `hackathons/sessions/*/content/`).