### PR TITLE
usoc23: Fix sessions rendering order

### DIFF
--- a/content/en/community/hackathons/usoc23/baby-steps/index.md
+++ b/content/en/community/hackathons/usoc23/baby-steps/index.md
@@ -1,7 +1,7 @@
 ---
 title: Session 02 - Baby Steps
 linkTitle: Bulding Unikernels
-weight: 5
+weight: 2
 summary: |
   We start presenting the modular architecture of Unikraft and how students can build their unikernels using the manual, `make`-based approach.
   Expected time: 100 minutes

--- a/content/en/community/hackathons/usoc23/behind-the-scenes/index.md
+++ b/content/en/community/hackathons/usoc23/behind-the-scenes/index.md
@@ -1,7 +1,7 @@
 ---
 title: Session 03 - Behind the Scenes
 linkTitle: Working with Unikraft
-weight: 5
+weight: 3
 summary: |
   Interacting with Unikraft by modifying configs and writing first lines of code.
   Expected time: 100 minutes

--- a/content/en/community/hackathons/usoc23/overview/index.md
+++ b/content/en/community/hackathons/usoc23/overview/index.md
@@ -1,7 +1,7 @@
 ---
 title: Session 01 - Overview of Unikraft
 linkTitle: Setting Up Unikraft
-weight: 5
+weight: 1
 summary: |
   We present the initial steps in setting up the Unikraft development / usage environment.
   Students will use the basic Unikraft toolchain to set up, configure, build and run Unikraft images.

--- a/content/en/community/hackathons/usoc23/registration-challenges/_index.md
+++ b/content/en/community/hackathons/usoc23/registration-challenges/_index.md
@@ -2,6 +2,7 @@
 title: "Registration Challenges"
 date: 2023-04-12T01:10:00+02:00
 draft: false
+weight: 20
 collapsible: true
 description: Unikraft Summer of Code 2023, Registration Challenges
 ---


### PR DESCRIPTION
The sessions rendering order was wrong, since the `weight` attribute was not set in the index files header.