### PR TITLE
blog: Add info on selected GSoC'23 projects

### DIFF
--- a/content/en/blog/2023-07-10-unikraft-gsoc23.md
+++ b/content/en/blog/2023-07-10-unikraft-gsoc23.md
@@ -1,0 +1,44 @@
++++
+title = "Five Unikraft Projects Selected at Google Summer of Code 2023"
+date = "2023-07-10T13:00:00+01:00"
+author = "Razvan Deaconescu"
+tags = ["announcement"]
++++
+
+<img width="100px" src="https://summerofcode.withgoogle.com/assets/media/gsoc-2023-badge.svg" align="right" />
+
+It is our pleasure to announce that five Unikraft projects are part of [Google Summer of Code 2023 (GSoC'23)](https://summerofcode.withgoogle.com/).
+This is a build up of the [three excellent Unikraft projects](/blog/2022-05-21-unikraft-gsoc-org/) that took part last year in Google Summer of Code 2022.
+
+For GSoC'23, we presented an [extensive list of project ideas](https://github.com/unikraft/gsoc/blob/staging/gsoc-2023/ideas.md).
+We've had 17 applications, out of which 5 were selected and are currently funded for GSoC'23.
+
+See information about the projects and applicants below, and in their corresponding [blog posts](/blog).
+
+[**Expanding Binary Compatibility Mode**](/blog/2023-06-23-unikraft-gsoc-app-compat-1/)
+
+* applicant: [Tianyi Liu](https://github.com/i-Pear), from [Nanjing University](https://www.nju.edu.cn/en/) in China
+* mentors: [Simon Kuenzer](https://github.com/skuenzer), [Andra Paraschiv](https://github.com/andraprs), [Ștefan Jumărea](https://github.com/StefanJum), [Răzvan Deaconescu](https://github.com/razvand)
+
+[**Packaging Pre-built Micro-libraries for Faster and More Secure Builds**](/blog/2023-06-23-unikraft-gsoc-packaging-libs-1/)
+
+* applicant: [Zeyu Li](https://github.com/zyllee), from [Guizhou University](https://www.gzu.edu.cn/en/) in China
+* mentors: [Antoine Cotten](https://github.com/antoineco), [Alexander Jung](https://github.com/nderjung), [Cezar Crăciunoiu](https://github.com/craciunoiuc)
+
+[**Arm CCA Support for Unikraft**](/blog/2023-06-23-unikraft-gsoc-arm-cca-1/)
+
+* applicant: [Xingjian Zhang](https://github.com/zhxj9823), from [Zhejiang University](https://www.zju.edu.cn/english/) in China
+* mentors: [Michalis Pappas](https://github.com/michpappas), [Hugo Lefeuvre](https://github.com/hlef), [Răzvan Vîrtan](https://github.com/razvanvirtan), [Maria Sfîrăială](https://github.com/mariasfiraiala), [Vlad Bădoiu](https://github.com/vladandrew)
+
+[**Enhancing the VSCode Developer Experience**](/blog/2023-06-23-unikraft-gsoc-enhancing-vscode-developer-experience/)
+
+* applicant: [MD Sahil](https://github.com/MdSahil-oss), from [Maharshi Dayanand University](https://mdu.ac.in/) in India
+* mentors: [Alexander Jung](https://github.com/nderjung), [Cezar Crăciunoiu](https://github.com/craciunoiuc)
+
+[**re:Arch Unikraft**](/blog/2023-06-22-unikraft-gsoc-plat-rearch/)
+
+* applicant: [Rareș Miculescu](https://github.com/rares-miculescu), from [University POLITEHNICA of Bucharest](https://upb.ro/en/) in Romania
+* mentors: [Marc Rittinghaus](https://github.com/marcrittinghaus), [Simon Kuenzer](https://github.com/skuenzer), [Michalis Pappas](https://github.com/michpappas), [Răzvan Deaconescu](https://github.com/razvand), [Sergiu Moga](https://github.com/mogasergiu)
+
+Congratulations to the applicants.
+Thanks for the work done so far and keep it up!


### PR DESCRIPTION
Add information on the five selected GSoC'23 projects: link to blog post, student and mentors. Detailed information on each project is part of the corresponding blog post.