### PR TITLE
hackathons/registration: Hide challenges section

### DIFF
--- a/content/en/community/hackathons/sessions/registration-challenges/index.md
+++ b/content/en/community/hackathons/sessions/registration-challenges/index.md
@@ -1,0 +1,4 @@
+---
+title: Hackathon Registration Challenges
+draft: true
+---


### PR DESCRIPTION
Since the challenges section did not have an index file, empty sections to every challenge would appear in the sidebar menu. Add a simple index file that marks the challenges as drafts so the empty sections do not show up anymore.
The challenges will be refered when needed from a hackathon page, like it is done in the `usoc23/registration-challenges/*.md` files.