### PR TITLE
docs/contributing: Update links to GitHub issues

### DIFF
--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -11,11 +11,11 @@ collapsible: true
 This page contains information about how to get started with contributing to the Unikraft Open-Source Project.
 In this guide, you will find details of the procedures put in place to make contributions, as well as recommended workflows, tools, and more to help you get started.
 
-If you are looking for ideas regarding possible contributions to Unikraft, we keep an up-to-date list of open projects, enhancements and bugs on the project's github main repo under the <a class="badge badge-pill badge-primary" href="#">kind/project</a>, [kind-enhancement](^kind-enhancement) and [kind-bug](^kind-bug) labels, respectively.
+If you are looking for ideas regarding possible contributions to Unikraft, we keep an up-to-date list of open projects, enhancements and bugs on the project's github main repo under the [kind/project](https://github.com/unikraft/unikraft/labels/kind%2Fproject), [kind-enhancement](https://github.com/unikraft/unikraft/labels/kind%2Fenhancement) and [kind-bug](https://github.com/unikraft/unikraft/labels/kind%2Fbug) labels, respectively.
 Please browse through it and if you have any questions, please do not hesitate to ask any questions you may have.
 
 We use [Discord](https://bit.ly/UnikraftDiscord) as the main community online channel.
-For any errors, issues or problems you may run into, you can also [open an issue](issues) or ask a question on the [Github Discussions forum](https://github.com/unikraft/unikraft/discussions).
+For any errors, issues or problems you may run into, you can also [open an issue](https://github.com/unikraft/unikraft/issues) or ask a quesissuestion on the [Github Discussions forum](https://github.com/unikraft/unikraft/discussions).
 
 ## Discord
 


### PR DESCRIPTION
The links to GitHub issues were used as relative links, since the old
documentation was migrated from GitHub.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
