### PR TITLE
Stefan jum/link aveiro hackathon to guides

### DIFF
--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -50,5 +50,3 @@ We have collected PIE executables in:
 
 The binary compatibility layer is a very important part of the Unikraft unikernel.
 It helps us run applications that were not build for Unikraft while, at the same time, keeps the classic benefits of Unikraft: speed, security and small memory footprint.
-
-TODO: Add kraftkit bincompat instructions

--- a/content/hackathons/2023-09-aveiro/index.mdx
+++ b/content/hackathons/2023-09-aveiro/index.mdx
@@ -65,17 +65,17 @@ As part of the Unikraft community, [Răzvan Deaconescu](https://github.com/razva
 
 #### Friday, September 15, 2023
 
-| Time (WEST)   | Session                                                              |
-| ------------- | -------------------------------------------------------------------- |
-| 10:00 - 10:15 | Overview of Unikernels and Unikraft                                  |
-| 10:15 - 11:15 | Introduction to Unikraft: Building and Running Standard Applications |
-| 11:15 - 11:30 | Break                                                                |
-| 11:30 - 12:45 | Unikraft Internals: Building, Configuring, Using Libraries           |
-| 12:45 - 14:00 | Lunch                                                                |
-| 14:00 - 15:00 | Running (Complex) Applications in Unikraft                           |
-| 15:00 - 16:00 | Porting Applications to Unikraft                                     |
-| 16:00 - 16:15 | Break                                                                |
-| 16:15 - 17:45 | Porting Applications to Unikraft                                     |
+| Time (WEST)   | Session                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| 10:00 - 10:15 | [Overview of Unikernels and Unikraft](/guides/intro)                                     |
+| 10:15 - 11:15 | [Introduction to Unikraft: Building and Running Standard Applications](/guides/overview) |
+| 11:15 - 11:30 | Break                                                                                    |
+| 11:30 - 12:45 | [Unikraft Internals: Building, Configuring, Using Libraries](/guides/internals)          |
+| 12:45 - 14:00 | Lunch                                                                                    |
+| 14:00 - 15:00 | [Running (Complex) Applications in Unikraft](/guides/internals)                          |
+| 15:00 - 16:00 | [Porting Applications to Unikraft](/guides/bincompat)                                    |
+| 16:00 - 16:15 | Break                                                                                    |
+| 16:15 - 17:45 | [Porting Applications to Unikraft](/guides/bincompat)                                    |
 
 #### Saturday, September 16, 2023
 


### PR DESCRIPTION
Add links to the Aveiro hackathon front page that will point to the guides.
Most of the instructions will be placed inside application repositories, the guides will mainly send people there.