### PR TITLE
Add Loupe ASPLOS'24 paper

### DIFF
--- a/data/papers.yaml
+++ b/data/papers.yaml
@@ -1,3 +1,18 @@
+- title: "Loupe: Driving the Development of OS Compatibility Layers"
+  venue: ACM ASPLOS'24
+  year: 2024
+  url: https://doi.org/10.1145/3617232.3624861
+  pdf: https://arxiv.org/pdf/2309.15996.pdf
+  authors:
+    - Lefeuvre, H.
+    - Gain, G.
+    - Bădoiu, V-A.
+    - Dinca, D.
+    - Schiller, V-R.
+    - Raiciu, C.
+    - Huici, F.
+    - Olivier, P.
+
 - title: "Want More Unikernels? Inflate Them!"
   venue: ACM SoCC'22
   year: 2022


### PR DESCRIPTION
Add our Loupe ASPLOS'24 paper. ASPLOS'24 is the 28th edition of the ACM International Conference on Architectural Support for Programming Languages and Operating Systems. The paper, "Loupe: Driving the Development of OS Compatibility Layers", was accepted to appear in Volume 1. The methods described in this paper were central to the early development of Unikraft.

NOTE: The DOI URL does not resolve yet, but it is valid and will point to the ACM paper page once it is up.

More info: https://www.asplos-conference.org/asplos2024/