### PR TITLE
configs/internals: Remove reference to coding conventions

### DIFF
--- a/configs/internals.sidebar.json
+++ b/configs/internals.sidebar.json
@@ -16,10 +16,6 @@
               "path": "/docs/internals/build-process"
             },
             {
-              "title": "Coding Conventions",
-              "path": "/docs/internals/coding-conventions"
-            },
-            {
               "title": "Build System - Internals",
               "path": "/docs/internals/build-system"
             },


### PR DESCRIPTION
The cofing conventions are under `contributing/`, not under `internals/`. This would result in a 404 error.