### PR TITLE
guides/bincompat.mdx: Fix "binray" typo

### DIFF
--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -54,7 +54,7 @@ git clone https://github.com/unikraft/dynamic-apps
 
 ### Hello World
 
-In order to quickly run a `helloworld` application in binray compatibility mode, you can use the `run.sh` script in the `run-app-elfloader` repository:
+In order to quickly run a `helloworld` application in binary compatibility mode, you can use the `run.sh` script in the `run-app-elfloader` repository:
 
 ```console
 cd run-app-elfloader/


### PR DESCRIPTION
Replace 'binray' with 'binary'.