### PR TITLE
guides/bitcompat.mdx: Fix typo

### DIFF
--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -219,7 +219,7 @@ server_static sqlite3 sqlite3_static
 
 The list of apps are arguments to be passed to the script.
 
-Use the commands below to run, respectively, the helloworld, HTTP serverand Nginx apps:
+Use the commands below to run, respectively, the helloworld, HTTP server, and Nginx apps:
 
 ```console
 ./run_app.sh helloworld


### PR DESCRIPTION
Add missing space and comma.