### PR TITLE
bincompat.mdx: Fix "nount" typo

### DIFF
--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -279,7 +279,7 @@ Similarly, to run `grep`, use the command below:
 ./run.sh -r / /bin/grep "bash" /etc/passwd
 ```
 
-The commands nount the entire host filesystem to Unikraft and, in doing so, make all executables available to be tested.
+The commands mount the entire host filesystem to Unikraft and, in doing so, make all executables available to be tested.
 
 ### Practice: Run Filesystem Executables
 


### PR DESCRIPTION
Fixed "nount" typo to "mount".