### PR TITLE
guides/bincompat.mdx: Reshuffle the words order

### DIFF
--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -383,7 +383,7 @@ When encountering problems with binary compatibility mode, use either system cal
 ### Using GDB
 
 Tracing and debug messages may not be enough to identify the cause of certain issues.
-For that you want to follow the application control flow, be able to step instructions, print variable values.
+For that you want to follow the control flow of the application, be able to follow the instructions and print variable values.
 In short, you require the use of a debugger, such as GDB.
 
 See instructions in [the `README.md` file of the `app-elfloader` repository](https://github.com/unikraft/app-elfloader) about the use of GDB for debugging.

--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -414,7 +414,7 @@ Supported binaries must be PIE (**Position-Independent Executables**), either st
 
 ### Pre-built Binaries
 
-Once an application dynamic binary is obtained, we need to extract the required dynamic libraries.
+Once a dynamic binary application is obtained, we need to extract the required dynamic libraries.
 This step is only required for dynamic binaries;
 static binaries aren't using dynamic libraries.
 For this we use [the `extract.sh` script](https://github.com/unikraft/dynamic-apps/tree/master/extract.sh) in the `dynamic-apps` repository.

--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -285,8 +285,8 @@ The commands nount the entire host filesystem to Unikraft and, in doing so, make
 
 Run as many executables as possible from the host filesystem on top of Unikraft, using the binary compatibility layer.
 As potential items, use `/bin/head`, `/usr/bin/sort`, `/bin/zip`.
-A good option is Python;
-you need the path to the actual Linux executable, not a symbolic link.
+A good option would be Python.
+You need the path to the actual Linux executable, not a symbolic link.
 
 <Info>
 Note that certain executables will not work due to features not being supported by Unikraft:


### PR DESCRIPTION
Reshuffle the word order: "an application dynamic binary" -> "a dynamic binary application"