### PR TITLE
hackathons/sosp-23: Add links to content sessions

### DIFF
--- a/content/hackathons/2023-10-sosp/index.mdx
+++ b/content/hackathons/2023-10-sosp/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SOSP 2023"
 slug: /hackathons/2023-10-sosp
-description: Unikraft SOSP Tutorial, October 26-28, 2023
+description: Unikraft SOSP Tutorial, October 23, 2023
 startDate: 2023-10-23
 registerForm: https://sosp2023.mpi-sws.org/reg.html
 image: /hackathons/2023-10-sosp-cover.png
@@ -35,14 +35,14 @@ As part of the Unikraft community [Răzvan Deaconescu](https://github.com/razvan
 
 ### Schedule
 
-| Time (CEST)   | Session                                                              |
-| ------------- | -------------------------------------------------------------------- |
-| 08:30 - 08:45 | Overview of Unikernels and Unikraft                                  |
-| 08:45 - 10:00 | Introduction to Unikraft: Building and Running                       |
-| 10:00 - 10:30 | Break                                                                |
-| 10:30 - 12:00 | Unikraft Internals: Building, Configuring, Using Libraries           |
-| 12:00 - 13:30 | Lunch                                                                |
-| 13:30 - 15:00 | Running (Complex) Applications in Unikraft                           |
-| 15:00 - 15:30 | Break                                                                |
-| 15:30 - 16:45 | Porting Applications to Unikraft                                     |
-| 16:45 - 17:00 | Closing Remarks                                                      |
+| Time (CEST)   | Session                                                                                              |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| 08:30 - 08:45 | [Introduction to Unikernels and Unikraft](/guides/intro)                                             |
+| 08:45 - 10:00 | [First Steps with Unikraft: Building and Running Standard Applications](/guides/overview)            |
+| 10:00 - 10:30 | Break                                                                                                |
+| 10:30 - 12:00 | [Unikraft Internals: Building, Configuring, Using Libraries](/guides/internals)                      |
+| 12:00 - 13:30 | Lunch                                                                                                |
+| 13:30 - 15:00 | [Binary Compatibility: Running Native Linux Applications](/guides/bincompat)                         |
+| 15:00 - 15:30 | Break                                                                                                |
+| 15:30 - 16:45 | [Add New Native Linux Applications](/guides/bincompat)                                               |
+| 16:45 - 17:00 | Closing Remarks                                                                                      |


### PR DESCRIPTION
Add session links for SOSP tutorial / hackathon. Session links point to guides pages.