### PR TITLE
Fix a typo in testing.mdx

### DIFF
--- a/content/guides/testing.mdx
+++ b/content/guides/testing.mdx
@@ -20,7 +20,7 @@ Our shop also has at least an image for every product which should maximize when
 To test this, we would write a **unit test**.
 
 Running the test suite after each change is called **regression testing**.
-**Automatic testing** means that the tests are run and verified automatically and are usually triggered by contributiosn (pull requests).
+**Automatic testing** means that the tests are run and verified automatically and are usually triggered by contributions (pull requests).
 **Automated regression testing** is the best practice in software engineering.
 
 One of the key metrics used in testing is **code coverage**.


### PR DESCRIPTION
I found a typo while going through `content/guides/testing.mdx`