### PR TITLE
fix: Update DuckDB's broken link

### DIFF
--- a/src/components/landing/catalog-strip.tsx
+++ b/src/components/landing/catalog-strip.tsx
@@ -175,7 +175,7 @@ export function CatalogStrip(props: BoxProps) {
             <Image alt='Caddy' src={`/logos/app-caddy.svg`} maxW='20' minH='24' mx='auto' />
           </AppLink>
           <AppLink
-            href='https://github.com/unikraft/catalog/tree/main/exanokes/duckdb-go'
+            href='https://github.com/unikraft/catalog/tree/main/examples/duckdb-go'
             accentColor='black'
             name='DuckDB'
           >


### PR DESCRIPTION
Fixes #396
This corrects a previously broken DuckDB link that led to a 404 page. 