### PR TITLE
replace old app links with links in catalog

### DIFF
--- a/content/docs/cli/building.mdx
+++ b/content/docs/cli/building.mdx
@@ -60,7 +60,7 @@ kraft menu
 <AsciinemaPlayer src="/asciinema/kraft-menu.cast" />
 
 In the above example, the ["Hello, world!" example
-application](https://github.com/unikraft/app-helloworld) was configured by hand
+application](https://github.com/unikraft/catalog/tree/main/examples/helloworld-c) was configured by hand
 using Unikraft's built-in [menuconfig](https://en.wikipedia.org/wiki/Menuconfig)
 system for `qemu/x86_64`.  Colored ANSI output and the internal test suite,
 `uktest`, were selected and enabled for the build.

--- a/content/docs/cli/packaging.mdx
+++ b/content/docs/cli/packaging.mdx
@@ -235,7 +235,7 @@ kraft pkg --as oci --name unikraft.org/helloworld:latest
    src="/asciinema/kraft-pkg-as-oci.cast" />
 
 In the above example, [a "Hello, world!"
-project](https://github.com/unikraft/app-helloworld) with a single target
+project](https://github.com/unikraft/catalog/tree/main/examples/helloworld-c) with a single target
 (`qemu/x86_64`) is packaged as an OCI image with the name
 `unikraft.org/helloworld:latest`.
 

--- a/content/docs/cli/running.mdx
+++ b/content/docs/cli/running.mdx
@@ -37,7 +37,7 @@ For long-running applications, typing <Kbd>Ctrl</Kbd> + <Kbd>C</Kbd> will only d
 See more about [stopping and removing the unikernel instance](#stopping-and-removing-unikernel-instances).
 </Warning>
 
-In the above example, the [offical "Hello, world" application](https://github.com/unikraft/app-helloworld) was run.
+In the above example, the [offical "Hello, world" application](https://github.com/unikraft/catalog/tree/main/examples/helloworld-c) was run.
 It has multiple targets with varying platforms and architecture tuples.
 When `kraft run` was invoked, it intelligently detected information about the host system and suggested two possible targets based on the availability of QEMU on the system.
 

--- a/content/docs/contributing/review-process.mdx
+++ b/content/docs/contributing/review-process.mdx
@@ -82,7 +82,7 @@ On this page, we detail how the process of a review of a PR occurs for both thos
    For new contributors, please run the `checkpatch.uk` program before creating the PR to streamline the review process.
    A reviewer will typically request for a rebase with the recommendations from the checkpatch before continuing with their review.
 
-1. Along with the `checkpatch.uk`, a number of consistency builds are run in parallel for known architectures and platforms against the [helloworld](https://github.com/unikraft/app-helloworld) Unikraft application with the branch of the PR.
+1. Along with the `checkpatch.uk`, a number of consistency builds are run in parallel for known architectures and platforms against the [helloworld](https://github.com/unikraft/catalog/tree/main/examples/helloworld-c) Unikraft application with the branch of the PR.
    These checks will appear at the bottom of the PR, like so:
 
 <Image

--- a/content/guides/overview.mdx
+++ b/content/guides/overview.mdx
@@ -59,7 +59,7 @@ echo "allow all" | sudo tee /etc/qemu/bridge.conf
 
 ## `app-helloworld` on Unikraft
 
-The Unikraft `helloworld` application is located in [this repository](https://github.com/unikraft/app-helloworld), along with instructions on how to configure, build and run the application.
+The Unikraft `helloworld` application is located in [this repository](https://github.com/unikraft/catalog/tree/main/examples/helloworld-c), along with instructions on how to configure, build and run the application.
 We will go through them without focusing that much on the details, since we will see how everything works behind the scenes in the next sessions.
 Go through the repository `README.md` file and run your first Unikraft unikernel.
 
@@ -68,9 +68,9 @@ Go through the repository `README.md` file and run your first Unikraft unikernel
 Now that you've seen how to run Unikraft `helloworld`, you can go through the list below, follow the same steps and try more applications.
 All the steps required for running the applications can be found in every app repository `README.md` file.
 
-* [`app-httpreply`](https://github.com/unikraft/app-httpreply)
-* [`app-nginx`](https://github.com/unikraft/app-nginx)
-* [`app-redis`](https://github.com/unikraft/app-redis)
-* [`app-sqlite`](https://github.com/unikraft/app-sqlite)
-* [`app-python3`](https://github.com/unikraft/app-python3)
+* [`app-httpreply`](https://github.com/unikraft/catalog/tree/main/examples/http-c)
+* [`app-nginx`](https://github.com/unikraft/catalog/tree/main/library/nginx/1.15)
+* [`app-redis`](https://github.com/unikraft/catalog/tree/main/library/redis/7.0)
+* [`app-sqlite`](https://github.com/unikraft/catalog/tree/main/library/sqlite/3.40)
+* [`app-python3`](https://github.com/unikraft/catalog/tree/main/library/python/3.10)
 


### PR DESCRIPTION
since some of the independent app repositories like https://github.com/unikraft/app-helloworld are no longer maintained, is it need to replace these links in doc with the catalog repository's link?