### PR TITLE
hackathons: Add landing page for Zagreb Unikraft Hackathon

### DIFF
--- a/content/hackathons/2024-05-zagreb/index.mdx
+++ b/content/hackathons/2024-05-zagreb/index.mdx
@@ -1,0 +1,90 @@
+---
+title: Zagreb 2024
+slug: /hackathons/2024-05-zagreb
+description: Zagreb Unikraft Hackathon, May 18-19, 2024
+startDate: 2024-05-18
+registerForm: https://forms.gle/VARSHAEzA7cHXDWTA
+image: /hackathons/2024-05-zagreb-cover.png
+address:
+- Algebra University
+- Gradišćanska 24, 10000
+- Zagreb
+- Croatia
+map: https://maps.app.goo.gl/YzGosE2kZSRTgdgw6
+partners:
+- name: Algebra University
+  url: https://www.algebra.hr
+- name: Croatian Association for Open Systems and Internet – HrOpen
+  url: https://www.dorscluc.org/organisation/hropen/
+- name: National University of Science and Technology POLITEHNICA of Bucharest (NUSTPB)
+  url: https://upb.ro/en/
+- name: Romanian Open Source Education (ROSEdu)
+  url: https://www.rosedu.org/en/
+hosts:
+- name: Mislav Balković
+  url: https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=69
+- name: Vedran Dakić
+  url: https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=92
+- name: Zlatan Morić
+  url: https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=77
+---
+
+Unikraft and [Algebra University](https://www.algebra.hr), [Croatian Association for Open Systems and Internet – HrOpen](https://www.dorscluc.org/organisation/hropen/), [National University of Science and Technology POLITEHNICA of Bucharest (NUSTPB)](https://upb.ro/en/), [Romanian Open Source Education (ROSEdu)](https://www.rosedu.org/en/) come together to organize the **Zagreb Unikraft Hackathon** to be held on Saturday and Sunday, May 18-19, 2024.
+
+The hackathon will be organized as part of the [DORS/CLUC 2024 event](https://www.dorscluc.org/).
+
+The hackathon will take place as an in-person event at the [Algebra University](https://www.algebra.hr/en/how-to-reach-us/).
+The full address is [Algebra University, Gradišćanska 24, 10000, Zagreb, Croatia](https://maps.app.goo.gl/YzGosE2kZSRTgdgw6)
+
+Support information and discussions will take place on [Discord](http://bit.ly/UnikraftDiscord), on the `#hack-zagreb24` channel.
+
+### Registration
+
+To take part in the hackathon please fill this [registration form](https://forms.gle/VARSHAEzA7cHXDWTA) by **Sunday, May 12, 2024, 11pm CEST**.
+
+### Requirements
+
+Please bring your own laptop.
+It's best if you have a native Linux installed on your laptop, but other OSes (Windows + WSL, macOS) should work as well.
+
+Make sure you have [KraftKit](https://github.com/unikraft/kraftkit) installed on your system.
+Follow the instructions [here](https://unikraft.org/docs/getting-started#quick-start).
+
+### People
+
+The hosts of the hackathon are:
+
+* [Mislav Balkovic](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=69)
+* [Vedran Dakić](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=92)
+* [Zlatan Morić](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=77)
+* [Valerija Olic](valerija@dorscluc.org)
+* [Andrei Crnković](andrei@dorscluc.org)
+* [Ivona Tenšek](ivona@dorscluc.org)
+* [Bruno Banelli](bruno.banelli@sartura.hr)
+* [Jakov Petrina](jakov.petrina@sartura.hr)
+* [Andrija Kranjec](andrija.kranjec@sartura.hr)
+
+As part of the Unikraft community, [Răzvan Deaconescu](https://github.com/razvand), [Cezar Crăciunoiu](https://github.com/craciunoiuc), [Ștefan Jumărea](https://github.com/StefanJum) and [Radu Nichita](https://github.com/RaduNichita) will be on-site.
+
+### Schedule
+
+#### Saturday, May 18, 2024
+
+| Time (CEST)    | Session                                                                                              |
+| -------------  | -----------------------------------------------------------------------------------------------------|
+| 09:00-09:30    | Introduction to Unikernels and Cloud Computing                                                       |
+| 09:30-11:00    | Deploying Cloud Applications using KraftCloud                                                        |
+| 11:00-12:30    | Behind the Scenes: Using KraftKit to Operate Unikraft Applications                                   |
+| 12:30-14:00    | Lunch                                                                                                |
+| 14:00-15:00    | Using Docker and Docker-based Filesystems                                                            |
+| 15:00-16:00    | Debugging Unikraft / KraftCloud Applications                                                         |
+| 16:00-18:00    | Hackathon start: Announce Teams and Projects. Start Coding                                           |
+
+#### Sunday, May 19, 2024
+
+| Time (CEST)    | Session                                                                                              |
+| -------------  | -----------------------------------------------------------------------------------------------------|
+| 09:00-12:30    | Hackathon: Work on Project                                                                           |
+| 12:30-14:00    | Lunch                                                                                                |
+| 14:00-16:00    | Hackathon: Work on Project                                                                           |
+| 16:00-18:00    | Judging and Award Ceremony                                                                           |


### PR DESCRIPTION
Add landing page for Zagreb Unikraft Hackathon taking place as part of DORS / CLUC at the Algebra University, on Saturday-Sunday, May 18-19, 2024.