### PR TITLE
hack/zagreb: Add Svebor Prstacic to hosts

### DIFF
--- a/content/hackathons/2024-05-zagreb/index.mdx
+++ b/content/hackathons/2024-05-zagreb/index.mdx
@@ -57,6 +57,7 @@ The hosts of the hackathon are:
 * [Mislav Balkovic](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=69)
 * [Vedran Dakić](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=92)
 * [Zlatan Morić](https://www.algebra.hr/sveuciliste/en/lecturers-and-associates/lecturer/?id=77)
+* [Svebor Prstacic](svebor@dorscluc.org)
 * [Valerija Olic](valerija@dorscluc.org)
 * [Andrei Crnković](andrei@dorscluc.org)
 * [Ivona Tenšek](ivona@dorscluc.org)


### PR DESCRIPTION
Svebor Prstacic is the lead contact for DORS / CLUC.