### PR TITLE
Fix: Typo in testing-concepts.mdx

### DIFF
--- a/content/guides/testing-concepts.mdx
+++ b/content/guides/testing-concepts.mdx
@@ -20,7 +20,7 @@ Our shop also has at least an image for every product which should maximize when
 To test this, we would write a **unit test**.
 
 Running the test suite after each change is called **regression testing**.
-**Automatic testing** means that the tests are run and verified automatically and are usually triggered by contributiosn (pull requests).
+**Automatic testing** means that the tests are run and verified automatically and are usually triggered by contributions (pull requests).
 **Automated regression testing** is the best practice in software engineering.
 
 One of the key metrics used in testing is **code coverage**.


### PR DESCRIPTION
Hi all!

I was going through the docs and noticed a small typo in the word contributions [here](https://unikraft.org/guides/testing-concepts). I noticed there was a similar PR #376, but seeing as it's almost been two months with no update and the docs have changed since, hopefully this is more up-to-date.