### PR TITLE
blog: Announce GSoC'24 participants

### DIFF
--- a/content/blog/2024-05-10-unikraft-gsoc24.mdx
+++ b/content/blog/2024-05-10-unikraft-gsoc24.mdx
@@ -1,0 +1,50 @@
+---
+title: "Five Unikraft Projects Selected at Google Summer of Code 2024"
+description: |
+  It is our pleasure to announce that 5 Unikraft projects are part of Google Summer of Code 2024 (GSoC'24).
+publishedDate: 2024-05-10
+authors:
+- Răzvan Deaconescu
+tags:
+- gsoc
+- gsoc24
+- announcement
+---
+
+<img width="100px" src="/gsoc-badge.jpg" align="right" />
+
+It is our pleasure to announce that 5 Unikraft projects are part of [Google Summer of Code 2024 (GSoC'24)](https://summerofcode.withgoogle.com/) 🚀
+This is a continuation of the [5 Unikraft projects](/blog/2023-07-10-unikraft-gsoc23) that took part last year in Google Summer of Code 2023.
+
+For GSoC'24, we presented a [diverse list of project ideas](https://github.com/unikraft/gsoc/blob/staging/gsoc-2024/ideas.md).
+We've had 16 applications, out of which 5 were selected and are currently funded for GSoC'24.
+
+The 5 applicants, and their projects are:
+
+**[Mihnea Firoiu](https://github.com/Mihnea0Firoiu) from [POLITEHNICA Bucharest](https://www.upb.ro/en) in Bucharest, Romania**
+
+* Project: Linux x86 Boot Protocol Support
+* Mentors: [Ștefan Jumărea](https://github.com/StefanJum), [Răzvan Deaconescu](https://github.com/razvand), [Michalis Pappas](https://github.com/michpappas)
+
+**[Yang Hu](https://github.com/huyang531) from [University of Toronto](https://www.utoronto.ca/) in Toronto, Canada**
+
+* Project: Synchronization Support in Internal Libraries
+* Mentors: [Răzvan Vîrtan](https://github.com/razvanvirtan), [Radu Nichita](https://github.com/RaduNichita), [Marc Rittinghaus](https://github.com/marcrittinghaus)
+
+**[Ujjwal Mahar](https://github.com/UjjwalMahar) from [Sharda University](https://www.sharda.ac.in/) in Greater Noida, NCR, India**
+
+* Project: Supporting User-provided, Long-lived Environmental Variables for Unikraft Builds
+* Mentors: [Cezar Crăciunoiu](https://github.com/craciunoiuc), [Luca Serițan](https://github.com/LucaSeri), [Alexander Jung](https://github.com/nderjung)
+
+**[Maria Pană](https://github.com/mariapana) from [POLITEHNICA Bucharest](https://www.upb.ro/en) in Bucharest, Romania**
+
+* Project: Multiboot2 Support in Unikraft
+* Mentors: [Cristian Vijelie](https://github.com/cristian-vijelie), [Sergiu Moga](https://github.com/mogasergiu), [Michalis Pappas](https://github.com/michpappas)
+
+**[Sriprad Potukuchi](https://github.com/procub3r) from [PES University](https://pes.edu/) in Bengaluru, India**
+
+* Project: UEFI Graphics Output Protocol Support in Unikraft
+* Mentors: [Sergiu Moga](https://github.com/mogasergiu), [Răzvan Vîrtan](https://github.com/razvanvirtan), [Michalis Pappas](https://github.com/michpappas)
+
+Congratulations Mihnea, Yang, Ujjwal, Mia, Sriprad! 🥳
+Let's get hacking! 🛠️


### PR DESCRIPTION
Announce GSoC'24 Unikraft projects. Announce projects, applicants and mentors.