### PR TITLE
fixes the path of the .wslconfig file

### DIFF
--- a/content/docs/cli/install.mdx
+++ b/content/docs/cli/install.mdx
@@ -152,7 +152,7 @@ for Debian/Ubuntu](#debianubuntu) from within WSL2.
 
 Once installed, you must ensure that nested-virtualization is enabled.  This
 will allow you to [run Unikraft via QEMU for KVM later](#) by editing
-`/etc/wsl.conf`:
+`%UserProfile%\.wslconfig`:
 
 ```toml
 [wsl2]


### PR DESCRIPTION
fixes the path of the config file to the correct filepath according to the official documentation under https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconfig

reason:
Both files are config files for wsl2 but they have distinct config options and those stated to use are in the file .wslconfig inside the windows filesystem.