### PR TITLE
Add missing links to the "Contributing" page

### DIFF
--- a/content/docs/contributing/index.mdx
+++ b/content/docs/contributing/index.mdx
@@ -12,9 +12,9 @@ find details of the procedures of how to make a contribution, as well as
 recommended workflows, tools, and more.
 
 If you are looking for ideas regarding possible contributions to Unikraft, we
-keep an up-to-date list of [open projects](#), [enhancement ideas](#) and
-[bugs](#) on the project's GitHub organization.  Please browse through it and if
-you have any questions, please do not hesitate to [ask any questions](#) you may
+keep an up-to-date list of [open projects](https://github.com/unikraft/unikraft/projects?query=is%3Aopen), [enhancement ideas](https://github.com/unikraft/unikraft/issues?q=is%3Aissue+is%3Aopen+label%3Akind%2Fenhancement) and
+[bugs](https://github.com/unikraft/unikraft/issues?q=is%3Aissue+is%3Aopen+label%3Akind%2Fbug) on the project's GitHub organization.  Please browse through it and if
+you have any questions, please do not hesitate to ask any questions in our [Discord server](https://discord.gg/unikraft-762976922531528725) you may
 have.
 
 We use Discord as the main community online channel.  For any errors, issues or


### PR DESCRIPTION
The links in the "Contributing" page does not go anywere so I tried to fix that. 
I hope my contribution is useful 😊.