### PR TITLE
correct spelling in index.mdx

### DIFF
--- a/content/docs/concepts/index.mdx
+++ b/content/docs/concepts/index.mdx
@@ -72,7 +72,7 @@ of an Ubuntu VM), Containers and Unikernels, represented by Unikraft:
 | **Features**         | Everything you could think of | Depends on the needs              | Only the absolute necessary |
 
 
-## Componenization
+## Componentization
 
 At the heart of the unikernel model lies with the collection of composable,
 inter-changable and interoperable OS components which are formed into a library,


### PR DESCRIPTION
"componentization" was misspelled in a heading:
https://en.wiktionary.org/wiki/componentization