### PR TITLE
workshop-vienna: Update contents (names and links)

### DIFF
--- a/content/hackathons/2024-12-vienna/index.mdx
+++ b/content/hackathons/2024-12-vienna/index.mdx
@@ -54,33 +54,34 @@ As part of the Unikraft community, [Răzvan Deaconescu](https://github.com/razva
 | Time (CEST)    | Session                                                                                              |
 | -------------  | -----------------------------------------------------------------------------------------------------|
 | 09:00-09:30    | Introduction to Unikernels and Cloud Computing                                                       |
-| 09:30-11:00    | Deploying Cloud Applications using KraftCloud                                                        |
+| 09:30-11:00    | Deploying Cloud Applications using Unikraft Cloud                                                    |
 | 11:00-12:30    | Behind the Scenes: Using KraftKit to Operate Unikraft Applications                                   |
 | 12:30-14:00    | Lunch                                                                                                |
 | 14:00-15:00    | Using Docker and Docker-based Filesystems                                                            |
-| 15:00-16:00    | Debugging Unikraft / KraftCloud Applications                                                         |
-| 16:00-18:00    | Hackathon start: Announce Teams and Projects. Start Coding                                           |
+| 15:00-16:00    | Debugging Unikraft / Unikraft Cloud Applications                                                     |
+| 16:00-17:00    | First Principles Approach: Using Make and VMMs Directly                                              |
 
 #### Sunday, December 8, 2024
 
 | Time (CEST)    | Session                                                                                              |
 | -------------  | -----------------------------------------------------------------------------------------------------|
-| 09:00-12:30    | Hackathon: Work on Project                                                                           |
+| 09:00-10:30    | Unikraft Internals                                                                                   |
+| 10:30-12:30    | Project Work: Contribute to Unikraft, Unikraft Cloud, Application Catalogs                           |
 | 12:30-14:00    | Lunch                                                                                                |
-| 14:00-16:00    | Hackathon: Work on Project                                                                           |
-| 16:00-18:00    | Judging and Award Ceremony                                                                           |
+| 14:00-16:30    | Project Work                                                                                         |
+| 16:30-17:00    | Final Thoughts, Future Steps                                                                           |
 
-### Deploying Cloud Applications using KraftCloud
+### Deploying Cloud Applications using Unikraft Cloud
 
-If you did not create an account already, signup [here](https://console.kraft.cloud/signup) and get a `token`.
+If you did not create an account already, signup [here](https://console.unikraft.cloud/signup) and get a `token`.
 You will be using that in the following sessions.
 
-Once you have a token, follow the steps [here](http://docs.kraft.cloud/quickstart/) to deploy your first unikernel.
+Once you have a token, follow the steps [here](https://unikraft.cloud/docs/quickstart/) to deploy your first unikernel.
 If everything went well, deploy more applications following the tasks [here](TODO).
 
 ### Behind the Scenes: Using KraftKit to Operate Unikraft Applications
 
-In the previous session, you deployed application using KraftCloud.
+In the previous session, you deployed application using Unikraft Cloud.
 Now you will build and run Unikraft-based application locally.
 With this, you will get a better look at what `kraft cloud` does behind the scenes.
 
@@ -91,28 +92,28 @@ If you have extra time on your hands, go through the `Extra` section as well.
 
 ### Using Docker and Docker-based Filesystems
 
-In order to bring your own application on KraftCloud, you need to build a minimal required filesystem.
+In order to bring your own application on Unikraft Cloud, you need to build a minimal required filesystem.
 We do that using `docker`.
 This is useful both to understand what is happening behind the scenes and to have a test environment for your application.
-In case there are issues with KraftCloud / KraftKit, you can use Docker to see if everything is in the right place and to assist in debugging.
+In case there are issues with Unikraft Cloud / KraftKit, you can use Docker to see if everything is in the right place and to assist in debugging.
 
 Follow the steps [here](TODO) (only the ones under `Redis`) to see how you can port a new application on top of Unikraft.
 Mark the items as completed [here](TODO).
 Go through them orderly and aim to complete all items until the `Extra` section.
 If you have extra time on your hands, go through the `Extra` section as well.
 
-### Debugging Unikraft / KraftCloud Applications
+### Debugging Unikraft / Unikraft Cloud Applications
 
 When porting new applications, you can run into issues both on the Docker build and on the Unikraft runtime.
-To debug the issues, you can follow the instructions [here](https://docs.kraft.cloud/guides/features/debugging/).
+To debug the issues, you can follow the instructions [here](https://unikraft.cloud/docs/guides/features/debugging/).
 Get a hands-on experience with debugging by following the items [here](TODO).
 
 ### Hackathon
 
-For the hackathon, please create teams of 2-3 people, and create your very own cloud-native application to run on KraftCloud.
+For the hackathon, please create teams of 2-3 people, and create your very own cloud-native application to run on Unikraft Cloud.
 Think of a cool application you've been waiting for a while to implement.
-Use your preferred programming language (supported by KraftCloud), employ any frameworks or existing software components as required, and then deploy it on KraftCloud.
+Use your preferred programming language (supported by Unikraft Cloud), employ any frameworks or existing software components as required, and then deploy it on Unikraft Cloud.
 After you create a team and decide on a project, fill [this spreadsheet](TODO) with the team name, members and project idea.
 
-At the and of the hackathon, you should make a PR in the [KraftCloud `examples` repository](https://github.com/kraftcloud/examples) with your work.
+At the and of the hackathon, you should make a PR in the [Unikraft Cloud `examples` repository](https://github.com/unikraft-cloud/examples) with your work.
 We will be evaluating the project, focusing on functionality, originality, robustness, complexity, code quality and team work.

--- a/content/hackathons/2024-12-vienna/index.mdx
+++ b/content/hackathons/2024-12-vienna/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Vienna 2024
 slug: /hackathons/2024-12-vienna
-description: Vienna Unikraft Hackathon, December 7-8, 2024
+description: Vienna Unikraft Workshop, December 7-8, 2024
 startDate: 2024-12-7
 registerForm: https://forms.gle/oZzjm4bNUsWaf9C97
 image: /hackathons/workshop-vienna24.png
@@ -18,7 +18,7 @@ Unikraft and [SBA Research](https://www.sba-research.org/), together with [Natio
 The workshop will take place as an in-person event at the [SBA Research](https://www.sba-research.org/about/contact/).
 The full address is [SBA Research, Floragasse 7, 5th Floor, 1040, Vienna, Austria](https://maps.app.goo.gl/RF4DM83zz9qrLMBk7).
 
-Support information and discussions will take place on [Discord](http://bit.ly/UnikraftDiscord), on the `#hack-vienna24` channel.
+Support information and discussions will take place on [Discord](http://bit.ly/UnikraftDiscord), on the `#workshop-vienna24` channel.
 
 ### Registration
 

--- a/src/components/landing-hero.tsx
+++ b/src/components/landing-hero.tsx
@@ -18,8 +18,8 @@ import CopyButton from 'components/mdx-components/codeblock/copy-button'
 import { t } from 'utils/i18n'
 
 const announce = {
-  title: 'Unikraft Summer Workshop 2024',
-  href: '/hackathons/usw24',
+  title: 'Vienna Unikraft Workshop',
+  href: '/hackathons/2024-12-vienna',
 }
 
 export default function LandingHero() {


### PR DESCRIPTION
Update LATEST link. Use "Unikraft Cloud" instead of "KraftCloud". Use "workshop" instead of "hackathon".