### PR TITLE
docs/fix : Fix typo in Dockerfile script

### DIFF
--- a/content/docs/contributing/adding-to-the-app-catalog.mdx
+++ b/content/docs/contributing/adding-to-the-app-catalog.mdx
@@ -298,7 +298,7 @@ So we have a list of dependencies.
 With the information above we construct a minimized Docker environment in a `Dockerfile`:
 
 ```dockerfile
-FROM redis:7.2-bookworm as build
+FROM redis:7.2-bookworm AS build
 
 FROM scratch
 


### PR DESCRIPTION
Change "as" to "AS" to match case in Dockerfile script for redis:7.2-bookworm