### PR TITLE
docs/fix: Broken link to NCC Group Whitepaper.

### DIFF
--- a/content/docs/concepts/security.mdx
+++ b/content/docs/concepts/security.mdx
@@ -47,7 +47,7 @@ security and performance.
 Because of their intrinsic characteristics, unikernels projects have, in the
 past, claimed high security for cloud appliances. However, their security
 properties have been [called into
-question](https://research.nccgroup.com/wp-content/uploads/2020/07/ncc_group-assessing_unikernel_security.pdf),
+question](https://www.nccgroup.com/media/tgsj1css/_ncc_group-assessing_unikernel_security.pdf),
 as existing research prototypes failed to match mainstream OSes' security
 features, robustness, and testing. This aspect has historically been overlooked
 by unikernel prototypes for many reasons, including the fact that many, if not


### PR DESCRIPTION
The link to the NCC Group Whitepaper "Assessing Unikernel Security" seems to have moved from `https://research.nccgroup.com/wp-content/uploads/2020/07/ncc_group-assessing_unikernel_security.pdf` to `https://www.nccgroup.com/media/tgsj1css/_ncc_group-assessing_unikernel_security.pdf`. 

This PR would fix all (only one, actually) occurrences of the broken link.

I have not verified that they are exactly the same, as the old link is 404-ing. But based on the URL and content, I am pretty sure they are the same.