### PR TITLE
fix/info: Correct references to app catalog.

### DIFF
--- a/content/guides/internals.mdx
+++ b/content/guides/internals.mdx
@@ -34,7 +34,7 @@ They are located in specialized repositories in the [Unikraft organization](http
 
 `Application` is the actual application code.
 It typically provides the `main()` function (or equivalent) and is reliant on Unikraft and external libraries.
-Applications that have been ported on top of Unikraft are located in repositories in the [Unikraft organization](https://github.com/unikraft/), those whose names start with `app-`.
+Applications that have been ported on top of Unikraft are located in the [`catalog`](https://github.com/unikraft/catalog) repository. (You can find information on using the application catalog [here](/guides/using-the-app-catalog).)
 
 An important role of the core Unikraft component is providing support for different platforms and architectures.
 A platform is the virtualization / runtime environment used to run the resulting image (i.e QEMU, Firecracker, VMWare etc.).


### PR DESCRIPTION
With the shift to the app catalog, the Baby Steps page got left behind. This PR instead links readers to the [catalog repo](https://github.com/unikraft/catalog) and the [Using the Application Catalog](https://unikraft.org/guides/using-the-app-catalog) page.

Tasks:
- [ ] Ensure that the reference to the application catalog guide agrees with your writing standards.