### PR TITLE
docs: Upgrade make properclean to make distclean

### DIFF
--- a/content/guides/internals.mdx
+++ b/content/guides/internals.mdx
@@ -208,7 +208,7 @@ When you exit the menu, you will most likely see this warning message:
 This is a very good recommandation and you'll use it a lot when configuring and building applications - so make sure to run
 
 ```console
-$ make properclean
+$ make distclean
 ```
 
 ...followed by


### PR DESCRIPTION
Using `make distclean` avoids issues created from residual build artifacts.