### PR TITLE
Fixed broken links in index.mdx

### DIFF
--- a/content/docs/cli/index.mdx
+++ b/content/docs/cli/index.mdx
@@ -7,10 +7,10 @@ description: |
 ---
 
 Before beginning, it is important to familiarize yourself with [the concept of a
-unikernel](/docs/concepts/) and how unikernels differ from other runtime
+unikernel](https://unikraft.org/docs/concepts) and how unikernels differ from other runtime
 mediums, including: containers, standard VMs and OSes (e.g. Linux).  At the same
 time, a general understanding of [how a unikernel is constructed with
-Unikraft](/docs/internals/build-process) will help you understand how to use
+Unikraft](https://unikraft.org/docs/internals/build-process) will help you understand how to use
 `kraft` effectively.
 
 Please let us know if you run into any issues [by reaching out through one of
@@ -32,7 +32,7 @@ procedure.
 
 <Info>
 For more information on customizing your installation of `kraft`, please refer
-to the [complete installation guide](/docs/cli/install).
+to the [complete installation guide](https://unikraft.org/docs/cli/install).
 </Info>
 
 To test your installation, you can try running our pre-built "Hello, World"
@@ -218,6 +218,6 @@ FLAGS
 
 Once installed and running, learn more about:
 
-- [Building your first unikernel](/docs/cli/building)
-- [Packaging and distributing unikernels](/docs/cli/packaging)
-- [Running and managing multiple unikernels](/docs/cli/running)
+- [Building your first unikernel](https://unikraft.org/docs/cli/building)
+- [Packaging and distributing unikernels](https://unikraft.org/docs/cli/packaging)
+- [Running and managing multiple unikernels](https://unikraft.org/docs/cli/running)


### PR DESCRIPTION
This PR tracks the issue #372 
The fix was done by appending `https://unikraft.org` to build paths. 
Fixes #372 