### PR TITLE
blog/gsoc25: Fix year

### DIFF
--- a/content/blog/2025-05-22-unikraft-gsoc25.mdx
+++ b/content/blog/2025-05-22-unikraft-gsoc25.mdx
@@ -12,7 +12,7 @@ tags:
 - announcement
 ---
 
-It is our pleasure to announce that 5 Unikraft projects are part of [Google Summer of Code 2024 (GSoC'24)](https://summerofcode.withgoogle.com/) 🚀
+It is our pleasure to announce that 5 Unikraft projects are part of [Google Summer of Code 2025 (GSoC'25)](https://summerofcode.withgoogle.com/) 🚀
 This is a continuation of the [5 Unikraft projects](/blog/2023-07-10-unikraft-gsoc23) that took part in GSoC'23, and the [5 Unikraft projects](/blog/2024-04-10-unikraft-gsoc24) that took part in GSoC'24.
 
 For GSoC'25, we presented a [diverse list of project ideas](https://github.com/unikraft/gsoc/blob/staging/gsoc-2025/ideas.md).


### PR DESCRIPTION
Use 2025 as year for GSoC name, instead of the current incorrect value: 2024.