### PR TITLE
fix(docs): correct broken Hugo example link in catalog section

### DIFF
--- a/src/components/landing/catalog-strip.tsx
+++ b/src/components/landing/catalog-strip.tsx
@@ -205,7 +205,7 @@ export function CatalogStrip(props: BoxProps) {
             <Image alt='Go' src={`/logos/lang-go.svg`} maxW='28' minH='24' mx='auto' />
           </AppLink>
           <AppLink
-            href='https://github.com/unikraft/catalog/tree/main/examples/hugo'
+            href='https://github.com/unikraft/catalog/tree/main/examples/hugo/0.122'
             accentColor='black'
             name='Gohugo'
           >


### PR DESCRIPTION
The Hugo example link on the Unikraft website currently leads to a 404 error because the path `examples/hugo` no longer exists in the catalog repository.

Updated the link in `src/components/landing/catalog-strip.tsx` to point to the correct versioned path