### PR TITLE
content/contributing: Fix empty contributing links

### DIFF
--- a/content/docs/contributing/index.mdx
+++ b/content/docs/contributing/index.mdx
@@ -12,12 +12,12 @@ find details of the procedures of how to make a contribution, as well as
 recommended workflows, tools, and more.
 
 If you are looking for ideas regarding possible contributions to Unikraft, we
-keep an up-to-date list of [open projects](#), [enhancement ideas](#) and
-[bugs](#) on the project's GitHub organization.  Please browse through it and if
-you have any questions, please do not hesitate to [ask any questions](#) you may
+keep an up-to-date list of [open projects](https://github.com/unikraft/unikraft/issues?q=state%3Aopen%20label%3Akind%2Fproject), [enhancement ideas](https://github.com/unikraft/unikraft/issues?q=state%3Aopen%20label%3Akind%2Fenhancement) and
+[bugs](https://github.com/unikraft/unikraft/issues?q=state%3Aopen%20label%3Akind%2Fbug) on the project's GitHub organization.  Please browse through it and if
+you have any questions, please do not hesitate to ask any questions you may
 have.
 
-We use Discord as the main community online channel.  For any errors, issues or
+We use [Discord](https://unikraft.org/discord) as the main community online channel.  For any errors, issues or
 problems you may run into, you can also open an issue or ask a question on the
-Github Discussions forum.
+[Github Discussions forum](https://github.com/orgs/unikraft/discussions).
 


### PR DESCRIPTION
Replace link stubs on the contributing page with actual links. Also replace the generic "contact us" link with two separate more useful links to the official Discord and the GitHub discussions page.

This is a fix for issue #363, and a continuation of pull request #481.