### PR TITLE
docs/guides: Update advanced porting tutorial

### DIFF
--- a/content/guides/advanced-porting.mdx
+++ b/content/guides/advanced-porting.mdx
@@ -6,7 +6,7 @@ description: |
 
 In the previous sessions, we have explored porting a simple application to Unikraft.
 That required heavily changing the source code, which can lead to broken behavior.
-Today, we will learn how to properly port a more complex application, using multiple source file and build steps.
+Today, we will learn how to properly port a more complex application, using multiple source files and build steps.
 
 We will use [`iperf3`](https://github.com/esnet/iperf/tree/master) as an example, a network benchmarking tool.
 
@@ -30,7 +30,7 @@ Many of the principles in this tutorial, however, can be applied in the same way
 Namely, this may include additional build rules for target files, using specific compilers and linkers, etc.
 
 It is worth noting that we are only targeting compile-time applications in this tutorial.
-Applications written a runtime language, such as Python or Lua, require an interpreter which must be brought to Unikraft first.
+Applications written in a runtime language, such as Python or Lua, require an interpreter which must be brought to Unikraft first.
 There are already lots of these high-level languages supported by Unikraft.(e.g., [python](https://github.com/unikraft/catalog-core/python3-hello))
 If you wish to run an application written in such a language, please check out the list of available applications.
 However, if the language you wish to run is interpreted and not yet available on Unikraft, porting the interpreter would be in the scope of this tutorial, as the steps here would cover the ones needed to bring the interpreter, which is a program after all, as a Unikraft unikernel application.
@@ -46,7 +46,7 @@ It makes for an excellent application to be run as a Unikernel because:
 - It's [GNU Make](https://www.gnu.org/software/make/) and C-based
 - It's quite useful
 
-Bringing an application to Unikraft will involve understanding some of the way in which the application works, especially how it is built.
+Bringing an application to Unikraft will involve understanding some of the ways in which the application works, especially how it is built.
 Usually during the porting process we also end up diving through the source code, and in the worst-case scenario, have to make a change to it.
 More on this is covered [later in this tutorial](/guides/#patching-the-application).
 
@@ -54,47 +54,58 @@ We start by simply trying to follow the steps to compile the application from so
 
 ## Compiling the Application from Source
 
-The [`README`](https://github.com/esnet/iperf/blob/master/README.md) for the `iperf3` program has relatively simple build instructions, and uses GNU Make which is a first good sign.
+The [`README`](https://github.com/esnet/iperf/blob/master/README.md) for the `iperf3` program has relatively simple build instructions, and uses GNU Make which is a good first sign.
 Unikraft uses GNU Make to handle its internal builds and so when we see an application using Make, it makes porting a little easier.
 For non-Make type build systems, such as CMake or Bazel, it is still possible to bring this application to Unikraft, but the flags, files, and compile-time options, etc.
 will have to be considered with more care as they do not necessarily align in the same ways.
 It is still possible to bring an application using an alternative build system, but you must closely follow how the program is built in order to bring it to Unikraft.
 
-Let's walk through the build process of `iperf3` from its `README`:
+For this tutorial we use a slightly older version of `iperf3`, in order to strip away some of the OS bloat and focus more on the logic of porting an application to Unikraft.
+While the latest versions offer performance tweaks for high-end **Linux** servers, the core logic of network testing remains the same.
+
+Let's walk through the build process of `iperf3` from its `README`.
 
 1. First we obtain the source code of the application:
 
    ```console
-   git clone https://github.com/esnet/iperf.git
+   # clone the repository
+   $ git clone https://github.com/esnet/iperf.git
+   $ cd ./iperf
+
+   # list the available versions
+   $ git tag -l
+
+   # switch to version 3.9
+   $ git checkout tags/3.9 -b unikraft-port
    ```
 
-1. Then, we are asked to configure and build the application:
+1. Then, we can configure and build the application on the host **Linux** system:
 
    ```console
-   cd ./iperf
-   ./configure;
-   make
+   $ ./configure
+   $ make
    ```
 
    This will generate the `iperf3` executable, located in `src/iperf3`.
 
-If this has worked for you, your terminal will be greeted with several pieces of useful information:
+If this has worked, the terminal will be greeted with several pieces of useful information:
 
 1. The first thing we did was run `./configure`: an auto-generated utility program part of the [`automake`](https://www.gnu.org/software/automake/) build system.
    Essentially, it checks the compatibility of your system and the program in question.
    If everything went well, it will tell us information about what it checked and what was available.
    Usually this `./configure`-type program will raise any issues when it finds something missing.
    One of the things it is checking is whether you have relevant shared libraries (e.g. `.so` files) installed on your system which are necessary for the application to run.
-   The application will be dynamically linked to these shared libraries and they will be referenced at runtime in a traditional Linux user space manner.
+   The application will be dynamically linked to these shared libraries and they will be referenced at runtime in a traditional **Linux** user space manner.
    If something is missing, usually you must use your Linux-distro's package manager to install this dependency, such as via `apt-get`.
 
    The `./configure` program also comes with a useful `--help` page where we can learn about which features we would like to turn on and off before the build.
    It's useful to study this page and see what is available, as these can later become build options for the application when it is brought to the Unikraft ecosystem.
+
    **If, however, there are library dependencies for the target application which do not exist within the Unikraft ecosystem, then these library dependencies will need to be ported first before continuing.**
    The remainder of this tutorial also applies to porting libraries to Unikraft.
 
 1. When we next run `make` in the sequence above, we can see the intermediate object files which are compiled during the compilation process before `iperf3` is finally linked together to form a final Linux user space binary application.
-   It can be useful to note these files down, as we will be compiling these files with respect to Unikraft's build system.
+   We will encounter those files later in the tutorial, so it can be useful to note these files down, as we will be compiling these files with respect to Unikraft's build system.
 
 You have now built `iperf3` for Linux user space and we have walked through the build process for the application itself.
 In the next section, we prepare ourselves to bring this application to Unikraft.
@@ -111,23 +122,59 @@ To get started, we must create a new library for our application.
 The premise here is that we are going to wrap or decorate the source code of `iperf3` with the _lingua franca_ of Unikraft's build system.
 That is, when we eventually build the application, the Unikraft build system will understand where to get the source code files from, which ones to compile and how, with respect to the rest of Unikraft's internals and other dependencies.
 
-We will start from the [`nginx`](https://github.com/unikraft/catalog-core/tree/main/nginx) application, since it has the same requirements as `iperf3`, as in a libc and a networking stack.
-First, create an empty directory under `workdir/libs/`, called `iperf3`:
+In this tutorial we will be referring the [`nginx`](https://github.com/unikraft/catalog-core/tree/main/nginx) application, since it has the same requirements as `iperf3`, as in a libc and a networking stack.
+
+In the Unikraft ecosystem there are certain guidelines as to how an application's layout should be.
+The aim of this tutorial is to go through all the steps of building an application from scratch, whilst following those guidelines.
+
+The first thing we need is a directory for the new application:
 
 ```console
-$ mkdir wordir/libs/iperf3/
+$ mkdir app-iperf3
+$ cd app-iperf3
+
+# this file must exist in all parts of the application (more on this later)
+$ touch Makefile.uk
+```
+
+Another vital part is having a directory containing the core components for building a Unikernel image.
+Having a visible directory inside the application workspace was preferred for easier development.
+
+```console
+$ mkdir workdir
+$ cd workdir
+
+# directory for external libraries
+$ mkdir libs
+
+# directory containing the Unikraft building blocks (internal libraries, makefiles, etc.)
+$ git clone https://github.com/unikraft/unikraft.git
+```
+
+Now, inside `libs` we need to make the relevant **already ported** external libraries available and create a new library for our application.
+
+```console
+# the new library
+$ mkdir iperf3
+```
+
+As mentioned above, because this application is very similar to `nginx`, it will use [`musl`](https://github.com/unikraft/lib-musl) and [`lwip`](https://github.com/unikraft/lib-lwip).
+
+```console
+$ git clone https://github.com/unikraft/lib-musl.git musl
+$ git clone https://github.com/unikraft/lib-lwip.git lwip
 ```
 
 Next, we need to create the 2 most relevant files for the Unikraft build system, `Config.uk` and `Makefile.uk`:
 
 ```console
-$ touch workdir/libs/iperf3/Config.uk
-$ touch workdir/libs/iperf3/Makefile.uk
+$ touch iperf3/Config.uk
+$ touch iperf3/Makefile.uk
 ```
 
 The `Makefile.uk` should have minimal details about the location of the `iperf3` archive online:
 
-```make
+```Makefile
 ################################################################################
 # Library registration
 ################################################################################
@@ -136,7 +183,7 @@ $(eval $(call addlib_s,libiperf3,$(CONFIG_LIBIPERF3)))
 ################################################################################
 # Original sources
 ################################################################################
-LIBIPERF3_VERSION=3.19
+LIBIPERF3_VERSION=3.9
 LIBIPERF3_BASENAME=iperf-$(LIBIPERF3_VERSION)
 LIBIPERF3_URL=https://github.com/esnet/iperf/archive/refs/tags/$(LIBIPERF3_VERSION).tar.gz
 $(eval $(call fetch,libiperf3,$(LIBIPERF3_URL)))
@@ -146,39 +193,74 @@ The `Config.uk` file will contain one option that will allow us to later select 
 
 ```kconfig
 config LIBIPERF3
-bool "lib iperf 3.14"
-default y
+   bool "lib iperf 3.9"
+   default y
 ```
+
+Those 2 files are very important and understanding their general components is highly recommended.
+
+The layout of those files can be confusing at first.
+The following is a valuable resource that explains in greater detail the structure of the `Config.uk` and `Makefile.uk` configuration files.
+-  [`USoC23: Session 6: Application Porting`](https://youtu.be/YOtiNJcgf30?t=1225)
+
+With that being said, we move to the next part of the build.
 
 ## Fetching the Application Source Code
 
-Now, we can modify the `nginx` [`Makefile`](https://github.com/unikraft/catalog-core/blob/main/nginx/Makefile) and replace `$(LIBS_BASE)/nginx` with `$(LIBS_BASE)/iperf3`, which will load the `iperf3` `Makefile.uk` file.
-After that, if we run `make menuconfig`, we should have a `iperf3` option under `Library Configuration -->`.
+Now, we have to let the application know how its components are structured. We used the `nginx` [`Makefile`](https://github.com/unikraft/catalog-core/blob/main/nginx/Makefile) as the building block and replaced `$(LIBS_BASE)/nginx` with `$(LIBS_BASE)/iperf3`, which will load the `iperf3` `Makefile.uk` file.
+For this, a `Makefile` must be created inside the `app-iperf3` directory.
 
-If we select that, we can run `make fetch` to download the source code of `iperf` for our application:
+```Makefile
+UK_ROOT ?= $(PWD)/workdir/unikraft
+UK_BUILD ?= $(PWD)/workdir/build
+UK_APP ?= $(PWD)
+LIBS_BASE = $(PWD)/workdir/libs
+
+# notice that the order changed, because of chained dependencies
+UK_LIBS ?= $(LIBS_BASE)/musl:$(LIBS_BASE)/lwip:$(LIBS_BASE)/iperf3
+
+.PHONY: all
+
+all:
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) L=$(UK_LIBS) A=$(UK_APP) O=$(UK_BUILD) $(MAKECMDGOALS)
+```
+
+After that, if we run `make menuconfig`, we should have our new library (i.e. `iperf3`) present under the `Library Configuration -->` section, along with all the others.
+
+If we select the libraries we set up, we can run `make fetch` to download their source code:
 
 ```console
 $ make menuconfig
 
-# Select Library Configuration --> lib iperf 3.14 and save
+# Select Library Configuration --> lib iperf 3.9
+# Select Library Configuration --> lib musl
+# Select Library Configuration --> lib lwip
+
+# Save the configuration
 
 $ make fetch
-make[1]: Entering directory ...
+[...]
+make: Entering directory ...
 LN      Makefile
-WGET    libiperf3: https://github.com/esnet/iperf/archive/refs/tags/3.14.tar.gz
-.../app-iperf/build/libiperf3/3.14.tar.gz          [  <=>                                                                                                                 ] 635,38K  2,66MB/s    in 0,2s
-UNTAR   libiperf3: 3.14.tar.gz
-make[1]: Leaving directory ...
+WGET    libiperf3: https://github.com/esnet/iperf/archive/refs/tags/3.9.tar.gz
+.../app-iperf3/build/libiperf3/3.9.tar.gz          [  <=>                                                                                                                 ] 635,38K  2,66MB/s    in 0,2s
+UNTAR   libiperf3: 3.9.tar.gz
+make: Leaving directory ...
 
 $ tree -L 2 workdir/build/libiperf3/
 workdir/build/libiperf3/
-|-- 3.14.tar.gz
+|-- 3.9.tar.gz
 |-- origin
-|   `-- iperf-3.14
+|   `-- iperf-3.9
 `-- uk_clean_list
 
 2 directories, 2 files
 ```
+
+From this point on, we will focus more on the `iperf3` library, as it is not as build-ready as the imported ones.
 
 ## Provide Build Sources to the Build System
 
@@ -186,13 +268,13 @@ The next thing we need to do is provide source files that need to be built for `
 
 Now we have everything set up.
 We can start an iterative process of building the target unikernel with the application.
-This process is usually very iterative because it requires building the unikernel step-by-step, including new files to the build, making adjustments, and re-building, etc.
+This process is usually very iterative because it requires building the unikernel step-by-step, including new files to the build, making adjustments, and rebuilding, etc.
 
 1. The first thing we must do before we start is to check that fetching the remote code for `iperf3` worked.
    The directory with the extracted contents should be located at:
 
    ```console
-   $ ls -lsh workdir/build/libiperf3/origin/iperf-3.14/
+   $ ls -lsh workdir/build/libiperf3/origin/iperf-3.9/
    total 1,0M
    372K -rw-r--r-- 1 stefan stefan 367K iul  8 00:47 aclocal.m4
    4,0K -rwxr-xr-x 1 stefan stefan 1,5K iul  8 00:47 bootstrap.sh
@@ -215,6 +297,7 @@ This process is usually very iterative because it requires building the unikerne
    ```
 
    If this has not worked, you must fiddle with the preamble at the top of the library's `Makefile.uk` to ensure that correct paths are being set.
+   The order in which they are configured matters as well.
    Remove the `build/` directory and try `make fetch` again.
 
 1. Now that we can fetch the remote sources, `cd` into this directory and perform the `./configure` step as above.
@@ -222,7 +305,7 @@ This process is usually very iterative because it requires building the unikerne
    The first is that it will generate (and this is very common for C-based programs) a `config.h` file:
 
    ```console
-   $ cd workdir/build/libiperf3/origin/iperf-3.14/
+   $ cd workdir/build/libiperf3/origin/iperf-3.9/
    $ ./configure
    [...]
    config.status: creating src/version.h
@@ -243,8 +326,8 @@ This process is usually very iterative because it requires building the unikerne
    Make an `include/` directory in the library's repository and copy the file:
 
    ```console
-   mkdir ~/workdir/app-iperf/workdir/libs/iperf3/include
-   cp workdir/build/libiperf3/origin/iperf-3.10.1/src/iperf_config.h ~/workdir/app-iperf/.unikraft/libs/iperf3/include
+   mkdir workdir/libs/iperf3/include
+   cp workdir/build/libiperf3/origin/iperf-3.9/src/iperf_config.h workdir/libs/iperf3/include
    ```
 
    Let's indicate in the `Makefile.uk` of the Unikraft library for `iperf3` that this directory exists, and should be used as a location to look for header files:
@@ -261,7 +344,7 @@ This process is usually very iterative because it requires building the unikerne
    The `make` might give an error at the end, but it's fine, we can ignore it.
 
    ```console
-   cd workdir/build/libiperf3/origin/iperf-3.14/
+   cd workdir/build/libiperf3/origin/iperf-3.9/
    make -n
    ```
 
@@ -295,10 +378,37 @@ This process is usually very iterative because it requires building the unikerne
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/cjson.c
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_api.c
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_error.c
-   ...
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_auth.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_client_api.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_locale.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_server_api.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_tcp.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_udp.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_sctp.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_util.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_time.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/dscp.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/net.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/tcp_info.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/timer.c
+   LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/units.c
    ```
 
-   **Note:** The path in the variable `LIBIPERF3_SRC` may need to be adjusted from the boilerplate code to match the layout of the application you are porting.
+   **Note:** In the context of a library's `Makefile.uk` there will be some variables that seem to appear out of nowhere, which can create confusion.
+   To solve this, here are resources that shed some light on the matter:
+
+   - [`Internals of the Build Process`](https://unikraft.org/docs/internals/build-system)
+   - [`USoC23: Session 6: Application Porting`](https://youtu.be/YOtiNJcgf30?t=1502)
+
+   To eliminate any residual confusion, should that be the case, the following list contains a few of the variables, with the corresponding paths:
+
+   ```
+   LIBNAME_ORIGIN -> .../workdir/build/libname/origin
+   LIBNAME_BASE   -> .../libs/libname
+   LIBNAME_BUILD  -> .../workdir/build/libname
+   ```
+
+   With this in mind, `LIBIPERF3_SRC` can be easily defined, as it is **not** a generated variable.
 
    **Note:** Some of the source files that are compiled might be test files, we should not add them to the Unikraft build system.
 
@@ -311,12 +421,30 @@ This process is usually very iterative because it requires building the unikerne
    Because the application has been configured and we have fetched the contents, we can simply try running the build in the Unikraft application directory:
 
    ```console
-   cd ~/workdir/app-iperf3
+   cd ~/app-iperf3
    make
    ```
 
+   **Note:** `make -j $(nproc)` can also be used for faster build.
+
+   **Note:** The `make` will generate errors.
+   We previously mentioned that the `iperf_config.h` file (the one in the `src` directory) will need edits.
+   One such edit will be disabling `openssl`:
+
+   ```
+   [...]
+   /* OpenSSL Is Available */
+   // #define HAVE_SSL 1
+   [...]
+   ```
+
+   The next errors will be solved in the exact same fashion.
+
+   **Note:** As this application is complex it still needs patching, so, while the unikernel build seems to have worked, booting will still fail.
+   To fix it, apply the patches described in the designated part of the guide.
+
 1. (Optional) This step occurs less frequently, but is still useful to discuss in the context of porting an application to Unikraft.
-   Remember in [the Unikraft build lifecycle](community/hackathons/sessions/basic-app-porting/#the-unikraft-build-lifecycle) that there is a step which occurs between fetching the remote original code and compiling it.
+   Remember in the Unikraft build lifecycle that there is a step which occurs between fetching the remote original code and compiling it.
    This step (3), known as `prepare`, is used to make modifications to the origin code before it is compiled.
    This may be useful for applications which have complex build systems or auxiliary files which need to be created or modified before they are built.
    Examples for preparing include:
@@ -375,7 +503,7 @@ The next section discusses how to create one of these patches.
 
 1. [The first patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0001-Fix-duplicate-import-of-netinet-tcp.h.patch) comes from an error which is thrown when compiling the `iperf_api.c` source file.
    This file is 3rd to be compiled from the list of complete source files.
-   In this file, we are receiving a duplicate import of `<netinent/tcp.h>`, simply removing this import fixes it, so the patch addresses this issue.
+   In this file, we are receiving a duplicate import of `<netinet/tcp.h>`, simply removing this import fixes it, so the patch addresses this issue.
 
 1. [The second patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0002-Disable-SO_SNDBUF-and-SO_RCVBUF-checks.patch) comes as a result of [missing functionality from LwIP](https://github.com/lwip-tcpip/lwip/blob/b0e347158d8db640c6891f9f31f4e6d19dca200b/src/include/lwip/sockets.h#L220).
    The issue was discovered once the application was fully ported and was able to boot and run.
@@ -389,9 +517,22 @@ The next section discusses how to create one of these patches.
    The patch solves this by setting the temporary (ramfs) path to `/`.
    An alternative solution is to make this path at boot.
 
+1. [The fourth patch](https://github.com/lancs-net/lib-iperf3/blob/staging/patches/0004-Disable-use-of-mmap-and-replace-with-mmalloc-and-fr.patch) addresses a limitation in how memory-mapped file descriptors are handled.
+   Although Unikraft has improved its POSIX support, mapping specific file descriptors via mmap can still lead to failures in minimalist unikernel configurations.
+   The patch replaces mmap with a standard malloc and ensures proper cleanup with free.
+
 The above patches represent example use cases where patches may be necessary to fix the application when bringing it to Unikraft.
 The possibilities presented in this tutorial are non-exhaustive, so take care.
 The next section discusses in detail how to create a patch for the target application or library.
+
+   **Note:** To finalize the build of the application, the above-mentioned patches need to be manually applied.
+   Then the `make` command should be used again.
+
+   **Note:** This specific version of the [`iperf3`](https://github.com/lancs-net/lib-iperf3.git) library is already ported to Unikraft, so it could have been added to the application in the same way we added `musl` and `lwip`.
+   After finishing the **manual** build, the approach mentioned above could be tested.
+   This will show the power of porting a library containing the necessary patches, then using it whenever necessary, removing most of the manual labor.
+
+   The next section shows how to build the patches, in order to make the library easy to port.
 
 #### Preparing a Patch for the Application
 
@@ -400,19 +541,20 @@ Note that providing patches are an unfortunate workaround to the inherent differ
 
 **Note:** When patches are created, they are also version-specific.
 
-As such, if you update the library or application's code (i.e. by updating, for example, the version number of `LIBIPER3_VERSION`), patches may no longer be apply-able and will then need to be updated accordingly.
+As such, if you update the library or application's code (i.e. by updating, for example, the version number of `LIBIPERF3_VERSION`), patches may no longer be apply-able and will then need to be updated accordingly.
 To make a patch:
 
 1. First, ensure that the remote origin code has been downloaded to the application's `build/` folder:
+
    ```console
-   cd ~/workspace/apps/iperf3
+   cd ~/app-iperf3
    make fetch
    ```
 
 1. Once the source files have been downloaded, turn it into a Git repository and save everything to an initial commit, in the case of `iperf3`:
 
    ```console
-   cd workdir/build/libiperf3/origin/iperf-3.10.1
+   cd workdir/build/libiperf3/origin/iperf-3.9
    git init
    git add .
    git commit -m "Initial commit"
@@ -435,13 +577,37 @@ To make a patch:
 1. The next step is to create a `patches/` folder within the Unikraft port of the library and to move the new `.patch` file into this folder:
 
    ```console
-   mkdir ~/workspace/libs/iperf3/patches
-   mv ~/workspace/apps/iperf3/build/libiperf3/origin/iperf-3.10.1/*.patch ~/workspace/libs/iperf3/patches
+   mkdir workdir/libs/iperf3/patches
+   mv workdir/build/libiperf3/origin/iperf-3.9/*.patch workdir/libs/iperf3/patches
    ```
 
 1. To register patches against Unikraft's build system such that they are applied before the compilation of all source files, simply indicate it in the library's `Makefile.uk`:
 
    ```Makefile
-   # Add or edit ~/workspace/libs/iperf3/Makefile.uk
+   # Add or edit workdir/libs/iperf3/Makefile.uk
    LIBIPERF3_PATCHDIR = $(LIBIPERF3_BASE)/patches
    ```
+
+### Booting the Unikernel and Testing the application
+
+After applying the patches the build should be finalized and the unikernel image created.
+There is one more thing that needs to be done.
+Checking if the unikernel is able to boot and run.
+The commands are very similar to those required for `nginx`.
+
+```console
+$ # setup the network bridge (if not already done)
+$ sudo ip link set dev virbr0 down 2>/dev/null
+$ sudo ip link del dev virbr0 2>/dev/null
+$ sudo ip link add dev virbr0 type bridge
+$ sudo ip address add 172.44.0.1/24 dev virbr0
+$ sudo ip link set dev virbr0 up
+
+$ sudo qemu-system-x86_64 \
+    -nographic \
+    -m 64 \
+    -cpu max \
+    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
+    -append "netdev.ip=172.44.0.2/24:172.44.0.1::: -- -s" \
+    -kernel workdir/build/app-iperf3_qemu-x86_64
+```


### PR DESCRIPTION
Add consistent paths to commands and more explanations for clarity.

Update the version of iperf to the latest released (3.20).

Fix minor typos and formatting issues.