### PR TITLE
fix(content): fix typos and grammar on concepts page

### DIFF
--- a/content/docs/concepts/index.mdx
+++ b/content/docs/concepts/index.mdx
@@ -71,7 +71,6 @@ of an Ubuntu VM), Containers and Unikernels, represented by Unikraft:
 | **Security**         | Very secure                   | Least secure of the 3             | Very secure                 |
 | **Features**         | Everything you could think of | Depends on the needs              | Only the absolute necessary |
 
-
 ## Componenization
 
 At the heart of the unikernel model lies with the collection of composable,
@@ -90,7 +89,6 @@ pre-existing libraries such as OpenSSL.
 > Read more about [Unikraft's modular
 > architecture](/docs/concepts/architecture).
 
-
 ## Configurability
 
 To meet the needs of a large variety of different use cases, KPIs and contexts,
@@ -100,10 +98,9 @@ first-class in Unikraft and enables developers to develop the best-in-class
 applications.
 
 In Unikraft, this system is enabled by a custom port of [Linux's KConfig
-system](#) which allows users to quickly and easily pick and choose which
-libraries to include in the build process, as well as to configure options for
-each of them, where available.
-
+system](https://docs.kernel.org/kbuild/kconfig-language.html) which allows users
+to quickly and easily pick and choose which libraries to include in the build
+process, as well as to configure options for each of them, where available.
 
 ## Tooling and Integrations
 


### PR DESCRIPTION
This PR fixes several minor typos, grammatical errors, and an incomplete sentence on the Concepts page to improve readability.