### PR TITLE
fix(footer): Replace Twitter icon with X (formerly Twitter)

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 import {
   BsGithub,
   BsLinkedin,
-  BsTwitter,
+  BsTwitterX,
   BsDiscord,
   BsYoutube,
 } from 'react-icons/bs'
@@ -44,9 +44,9 @@ const socials = [
     href: 'https://www.linkedin.com/company/unikraft-sdk/',
   },
   {
-    icon: BsTwitter,
-    label: 'Twitter',
-    href: 'https://twitter.org/UnikraftSDK',
+    icon: BsTwitterX,
+    label: 'X',
+    href: 'https://x.com/UnikraftSDK',
   },
   {
     icon: BsDiscord,


### PR DESCRIPTION
## Summary

- Replaced deprecated `BsTwitter` icon with `BsTwitterX` from `react-icons/bs`
- Updated social link label from `Twitter` to `X`
- Updated URL from `twitter.org/UnikraftSDK` to `x.com/UnikraftSDK`

## Why

Twitter rebranded to X in 2023. The old bird logo (`BsTwitter`) is outdated — this aligns the footer with the current X branding.

## Changes

- `src/components/footer.tsx` — icon, label, and href updated


## Fixed #542 

**Before**
<img width="762" height="379" alt="Screenshot From 2026-03-11 10-11-08" src="https://github.com/user-attachments/assets/2df9d02e-692b-42c5-bd20-3a15a125b92a" />


**After**
<img width="839" height="404" alt="Screenshot From 2026-03-12 15-37-30" src="https://github.com/user-attachments/assets/e7a1d7f6-ef64-4d5a-affe-41971e26dc7c" />
