### PR TITLE
fix(content): fix typos and grammar on concepts pages

### DIFF
--- a/content/docs/concepts/build-process.mdx
+++ b/content/docs/concepts/build-process.mdx
@@ -21,7 +21,7 @@ bind them togheter.
   the build process to generate a unikernel image."
 />
 
-The lifecycle of the construction of a Unikraft unikernel includes several
+The construction lifecycle of a Unikraft unikernel includes several
 distinct steps:
 
 1. Configuring the Unikraft unikernel application with compile-time options;
@@ -32,13 +32,13 @@ distinct steps:
 ## GNU Make-based build system
 
 Unikraft is a configurable operating system, where each component can be
-modified, configured, according to the user’s needs. This configuration is done
+modified and configured, according to the user’s needs. This configuration is done
 using a version of Kconfig, through the Config.uk files. In these files, options
 are added to enable libraries, applications and different components of the
 Unikraft core. The user can then apply those configuration options, using make
 menuconfig, which generates an internal configuration file that can be
 understood by the build system, .config. Once configured, the Unikraft image can
-be built, using make, and run, using the appropriate method (Linux ELF loader,
+be built using make and run, using the appropriate method (Linux ELF loader,
 qemu-kvm, xen, others).
 
 <Image
@@ -48,6 +48,6 @@ qemu-kvm, xen, others).
   src="/diagrams/build-process-makefile.svg"
   title="Figure 1"
   description="Overview of Unikraft's build process with respect to the
-  intermediate artfacts generated considered from the perspective of its GNU
+  intermediate artifacts generated, considered from the perspective of its GNU
   Make-based build system."
 />

--- a/content/docs/concepts/compatibility.mdx
+++ b/content/docs/concepts/compatibility.mdx
@@ -6,7 +6,7 @@ description: |
 ---
 
 <Info>
-Parts of this document contains extracts from [an article published to **USENIX
+Parts of this document contain extracts from [an article published to **USENIX
 ;login**](https://www.usenix.org/publications/loginonline/unikraft-and-coming-age-unikernels)
 about Unikraft.
 </Info>
@@ -28,12 +28,12 @@ This is the default build mode for the majority of Linux distributions, so it sh
 </Warning>
 
 <Info>
-Note that, because Linux binaries are included, constructing new Linux binaries requires a Linux or Linux-compatible development environement (such as WSL - _Windows Subsystem for Linux_).
+Note that, because Linux binaries are included, constructing new Linux binaries requires a Linux or Linux-compatible development environment (such as WSL - _Windows Subsystem for Linux_).
 This is only the case for building binaries -- prebuilt binaries can be used and the ELF loader app itself can be built on multiple platforms (Linux, Windows, macOS).
 </Info>
 
 Binary-compatible apps are located in the Unikraft [application `catalog` repository](https://github.com/unikraft/catalog).
-Follow the guides below to know how to use and develop for the application catalog:
+Follow the guides below to learn how to use and develop for the application catalog:
 
 - [Using the Application Catalog](/guides/using-the-app-catalog)
 - [Behind the Scenes with the Application Catalog](/guides/catalog-behind-the-scenes)
@@ -88,10 +88,10 @@ applications, respectively, suggesting that a large implementation effort would
 be required for an OS aiming at supporting even a small number of applications.
 
 However, in the process of implementing POSIX system calls and checking whether
-applications where actually running, we gathered anecdotal evidence that these
+applications were actually running, we gathered anecdotal evidence that these
 requirements were not as stringent as they seemed: whenever a system call is
 missing, the default behavior of Unikraft's system call shim layer is to stub it
-by returning `ENOSYS`; the result of this was that some applications where
+by returning `ENOSYS`; the result of this was that some applications were
 correctly running despite not having some of the system calls they invoked
 implemented, so we decided to take a closer look.
 
@@ -144,7 +144,7 @@ would suggest, and much less than the total system calls in the Linux API.
 To confirm this, we took a look at the applications' source code: in cases where
 the failure of a system call is non-critical for the execution of the program,
 the program can detect the error and decide to continue as usual, in which case
-stubbing works. This snippet from the Redis code-base is a good example:
+stubbing works. This snippet from the Redis codebase is a good example:
 
 ```clike
 if (getrlimit(RLIMIT_NOFILE,&limit) == -1) {
@@ -182,7 +182,7 @@ applications is relatively limited, and is even lower when considering partial
 support i.e. traditional workloads. We observe that the system calls that can be
 stubbed/faked vary among applications. As an indication, the number of system
 calls that would need to be effectively implemented for all these 5 applications
-to be supported is 78 for test suites and only 37 for traditional benchmarks
+to be supported is 78 for test suites and only 37 for traditional benchmarks.
 
 A second observation is that static analysis produces many false positives and
 as such yields a large overestimation of the system calls made by an

--- a/content/docs/concepts/design-principles.mdx
+++ b/content/docs/concepts/design-principles.mdx
@@ -1,7 +1,7 @@
 ---
 title: Design Principles
 description: |
-  Unikraft is designed to highly modular, enabling the best-in-class performance
+  Unikraft is designed to be highly modular, enabling the best-in-class performance
   and security guarantees for your application.  To discover the right approach
   and achieve these goals, understanding the limitations modern OSes was
   necessary.
@@ -74,7 +74,7 @@ This admittedly non-exhaustive list of application-specific optimizations
 implies that for each core functionality that a standard OS provides, there
 exists at least one or a few applications that do not need it. Removing such
 functionality would reduce code size and resource usage but would often require
-an important re-engineering effort.
+a significant re-engineering effort.
 
 
 ## Approaches to building a unikernel
@@ -127,9 +127,9 @@ task.
 />
 
 While full modularization is difficult, modularizing certain parts of a
-monolithic kernel has been done succesfully by Rump. There, the NetBSD kernel
+monolithic kernel has been done successfully by Rump. There, the NetBSD kernel
 was split into base layers (which must be used by all kernels), functions
-provided by the host (scheduling, memory allocation,etc) and so-called factions
+provided by the host (scheduling, memory allocation, etc.) and so-called factions
 that can be run on their own (e.g.  network or filesystem support). Rump goes
 some way towards achieving our goals, however there are still many dependencies
 left which require that all kernels have the base and hypercall layers.
@@ -172,13 +172,13 @@ reinvent the wheel (eg x86_64 KVM boot).
 
 Unikraft consists of three basic components:
 
-* **Library Components.** Unikraft modules TODO, each of which provides some
-  piece of functionality. As is expected of a library, they are the core
-  building blocks of an application. Libraries can be arbitrarily small (e.g., a
-  small library providing a proof-of-concept scheduler) or as large as standard
-  libraries like libc. However, libraries in Unikraft often wrap pre-existing
-  libraries, such as openssl, and as such existing applications can still make
-  use of relevant, existing systems without having to re-work anything.
+* **Library Components.** Unikraft relies on modular components, each of which
+  provides some piece of functionality. As is expected of a library, they are the
+  core building blocks of an application. Libraries can be arbitrarily small
+  (e.g., a small library providing a proof-of-concept scheduler) or as large as
+  standard libraries like libc. However, libraries in Unikraft often wrap
+  pre-existing libraries, such as openssl, and as such existing applications can
+  still make use of relevant, existing systems without having to re-work anything.
 
 * **Configuration.** Inspired by [Linux's KConfig
   system](https://www.kernel.org/doc/html/next/kbuild/kconfig-language.html),
@@ -187,12 +187,12 @@ Unikraft consists of three basic components:
   configure options for each of them, where available. Like KConfig, the menu
   keeps track of dependencies and automatically selects them where applicable.
 
-* **Build Tools.** To seamlessly build and manage Unikraft, its components,
-  configuration and its execution is a suite of tools ... core of Unikraft is a
-  suite of tools which aid in the creation of the final unikernel image.  Based
-  on [GNU Make](https://www.gnu.org/software/make/), it takes care of compiling
-  and linking all the relevant modules and of producing images for the different
-  platforms selected via the configuration menu.
+* **Build Tools.** To seamlessly build and manage Unikraft, its components, and
+  its configuration, Unikraft provides a dedicated suite of tools which aid in
+  the creation of the final unikernel image. Based on [GNU Make]
+  (https://www.gnu.org/software/make/), it takes care of compiling and linking
+  all the relevant modules and of producing images for the different platforms
+  selected via the configuration menu.
 
 
 Unikraft libraries are grouped into two large groups: core (or internal)

--- a/content/docs/concepts/efficiency.mdx
+++ b/content/docs/concepts/efficiency.mdx
@@ -8,12 +8,12 @@ description: |
 
 As a proof of concept, we have ported Unikraft to the Raspberry Pi 3 B+ and the
 Xilinx Ultra96-V2 devices. We compare Unikraft with off-the-shelf Alpine Linux
-and Raspbian OS as well as a specialized, stripped down Raspbian (removing
+and Raspbian OS as well as a specialized, stripped-down Raspbian (removing
 non-essential build tools, system packages and docs).
 
 We evaluate power consumption versus Linux when idle and when running a
 CPU-intensive calculation of π (see figure below); as shown, Unikraft can
-provide important power reduction in both scenarios in comparison to Linux
+provide significant power reduction in both scenarios compared to Linux
 (running only on a single core and with networking modules disabled, for fair
 comparison).
 
@@ -23,7 +23,7 @@ comparison).
   ratio={5/3}
   src="/diagrams/unikraft-energy-consumption.svg"
   title="Figure 1"
-  description="Rasberry Pi power use with Unikraft vs. Alpine and Raspbian when idle and when calculating π"
+  description="Raspberry Pi power use with Unikraft vs. Alpine and Raspbian when idle and when calculating π"
 />
 
 Note that while these tests were run on small ARM devices, the

--- a/content/docs/concepts/index.mdx
+++ b/content/docs/concepts/index.mdx
@@ -12,7 +12,7 @@ Unikraft.  This text serves to fully conceptualize all information to help you
 understand the reasoning behind Unikraft's design and implementation, as well as
 serve as reference for its architecture.
 
-> For more information on [how build your application with
+> For more information on [how to build your application with
 > Unikraft](/docs/cli/building) or [how to manage unikernel applications in
 > production](/docs/cli/running) please see the [getting started
 > documentation](/docs/getting-started).
@@ -39,13 +39,13 @@ Unikernels are specifically designed for use in cloud environments.  In most
 production systems often the standard unit of isolation is the VM since this
 provides the greatest degree of security for the enclosed application(s).  Its
 isolation is made possible directly by hardware primitives instead of OS-level
-(software) primitives.  However, a fully virtualized traditional VMs is too
+(software) primitives.  However, a fully virtualized traditional VM is too
 heavy for most applications which has led to the container-based model.
 Naturally, the evolution of running applications in the cloud has led to the
 model where containers are deployed within VMs due to the properties of each
 system (seen in (c) in Figure 1).  Kubernetes is a prime example of such
 deployment model (nodepools are generally deployed as VMs) and is the _de facto_
-orchestration framework container applications.
+orchestration framework for container applications.
 
 Unikernels find parallels from the themes developed in early microkernel design
 efforts.  For instance, virtualisation techniques offered by [Type-1
@@ -75,7 +75,7 @@ of an Ubuntu VM), Containers and Unikernels, represented by Unikraft:
 ## Componenization
 
 At the heart of the unikernel model lies with the collection of composable,
-inter-changable and interoperable OS components which are formed into a library,
+interchangeable and interoperable OS components which are formed into a library,
 known as a library OS (libOS).  These components can be logically organized in
 two types.  The first set of functionalities which enable essential runtime
 services, such as system resource virtualisation and device drivers.  The second
@@ -83,7 +83,7 @@ type of OS service is discussed in the next section, offering added-value
 capabilities to applications, like IP networking and file system access.
 
 In Unikraft, libraries are first-class and all libraries in the core are
-inter-changable, from the scheduler to the memory allocator and more.  To
+interchangeable, from the scheduler to the memory allocator and more.  To
 facilitate the use of the wider ecosystem, Unikraft allows for wrapping
 pre-existing libraries such as OpenSSL.
 
@@ -96,7 +96,8 @@ pre-existing libraries such as OpenSSL.
 To meet the needs of a large variety of different use cases, KPIs and contexts,
 configuration of library components allow users to tune specific attributes to
 their liking.  This ability to configure all parts of the unikernel is
-first-class in Unikraft and enables developers to develop the best-in-class 
+first-class in Unikraft and enables developers to develop the best-in-class
+applications.
 
 In Unikraft, this system is enabled by a custom port of [Linux's KConfig
 system](#) which allows users to quickly and easily pick and choose which

--- a/content/docs/concepts/index.mdx
+++ b/content/docs/concepts/index.mdx
@@ -71,7 +71,6 @@ of an Ubuntu VM), Containers and Unikernels, represented by Unikraft:
 | **Security**         | Very secure                   | Least secure of the 3             | Very secure                 |
 | **Features**         | Everything you could think of | Depends on the needs              | Only the absolute necessary |
 
-
 ## Componenization
 
 At the heart of the unikernel model lies with the collection of composable,
@@ -90,7 +89,6 @@ pre-existing libraries such as OpenSSL.
 > Read more about [Unikraft's modular
 > architecture](/docs/concepts/architecture).
 
-
 ## Configurability
 
 To meet the needs of a large variety of different use cases, KPIs and contexts,
@@ -100,10 +98,9 @@ first-class in Unikraft and enables developers to develop the best-in-class
 applications.
 
 In Unikraft, this system is enabled by a custom port of [Linux's KConfig
-system](#) which allows users to quickly and easily pick and choose which
-libraries to include in the build process, as well as to configure options for
-each of them, where available.
-
+system](https://docs.kernel.org/kbuild/kconfig-language.html) which allows users
+to quickly and easily pick and choose which libraries to include in the build
+process, as well as to configure options for each of them, where available.
 
 ## Tooling and Integrations
 

--- a/content/docs/concepts/performance.mdx
+++ b/content/docs/concepts/performance.mdx
@@ -11,7 +11,7 @@ You can find the full evaluation details and the description of Unikraft in gene
 
 ## Image Size
 
-In order to quantify image sizes in Unikraft, we generate a number of images for all combinations of DCE (Dead Code Elimnation) and LTO (Link Time Optimization), and for a helloworld VM and three other applications: nginx, Redis and SQLite.
+In order to quantify image sizes in Unikraft, we generate a number of images for all combinations of DCE (Dead Code Elimination) and LTO (Link Time Optimization), and for a helloworld VM and three other applications: nginx, Redis and SQLite.
 The results in Figure 1 show that Unikraft images are all under 2MBs for all of these applications.
 We further compare these results with other unikernels and Linux in Figure 2.
 As shown, Unikraft images are smaller than all other unikernel projects and comparable to Linux userspace binaries (note that the Linux sizes are just for the application;
@@ -96,7 +96,7 @@ Surprisingly, Unikraft is also 10%-60% faster than Native Linux in both cases.
 We attribute these results to the cost of system calls (aggravated by the presence of KPTI — the gap between native Linux and Unikraft narrows to 0-50% without KPTI), and possibly the presence of Mimalloc as system-wide allocator in Unikraft;
 unfortunately it is not possible to use Mimalloc as kernel allocator in Linux without heavy code changes.
 Note that we did try to LD_PRELOAD Mimalloc into Redis, but the performance improvement was not significant.
-We expect that the improvement would be more notable if Mimalloc were present at compile time instead of relying on the preloading mechanism (making the compiler aware of the allocator allows it to perform compile/link time optimizations) but we could not perform this experiment since Mimalloc is not natively supported by the current Redis code base.
+We expect that the improvement would be more notable if Mimalloc were present at compile time instead of relying on the preloading mechanism (making the compiler aware of the allocator allows it to perform compile/link time optimizations) but we could not perform this experiment since Mimalloc is not natively supported by the current Redis codebase.
 
 <Image
   border
@@ -108,7 +108,7 @@ We expect that the improvement would be more notable if Mimalloc were present at
 />
 
 Compared to Lupine on QEMU/KVM, Unikraft is around 50% faster on both Redis and Nginx.
-These results may be due to overcutting in Lupine's official configuration, scheduling differences (we select Unikraft's cooperative scheduler since it fits well with Redis's single threaded approach), or remaining bloat in Lupine that could not be removed via configuration options.
+These results may be due to overcutting in Lupine's official configuration, scheduling differences (we select Unikraft's cooperative scheduler since it fits well with the Redis's single threaded approach), or remaining bloat in Lupine that could not be removed via configuration options.
 Compared to OSv, Unikraft is about 35% faster on Redis and 25% faster for Nginx.
 Rump exhibits poorer performance: it has not been maintained for a while, effectively limiting the number of configurations we could apply.
 For instance, we could not set the file limits because the program that used to do it (rumpctrl) does not compile anymore.

--- a/content/docs/concepts/security.mdx
+++ b/content/docs/concepts/security.mdx
@@ -44,7 +44,7 @@ security and performance.
 
 ## Security Features and Testing: Matching Linux
 
-Because of their intrinsic characteristics, unikernels projects have, in the
+Because of their intrinsic characteristics, unikernel projects have, in the
 past, claimed high security for cloud appliances. However, their security
 properties have been [called into
 question](https://research.nccgroup.com/wp-content/uploads/2020/07/ncc_group-assessing_unikernel_security.pdf),
@@ -85,8 +85,8 @@ This effort is by nature a continuous, community-driven task, but we are expecti
 Note that, as shown in the table, some security features of mainstream OSes do
 not apply to Unikraft: this is the case, for example, with numerous software
 counter-measures against speculative execution vulnerabilities such as KPTI,
-unnecessary because of the presence of a single application in the virtual
-machine.
+which are unnecessary because of the presence of a single application in the
+virtual machine.
 
 ## Testing
 

--- a/content/docs/concepts/virtualization.mdx
+++ b/content/docs/concepts/virtualization.mdx
@@ -22,7 +22,7 @@ Virtual machines rely on hypervisors to run properly.
 
 A hypervisor incorporates hardware-enabled multiplexing and segmentation of
 compute resources in order to better utilize, better secure and better
-facilitate the instantenous runtime of user-defined programs.
+facilitate the instantaneous runtime of user-defined programs.
 By the means of a virtual machine, an operating system is unaware of the
 multiplexing which happens to facilitate its existence.
 The hypervisor emulates devices on behalf of the guest OS, including
@@ -35,14 +35,14 @@ The hypervisors can be classified in 2 categories: Type 1 and Type 2:
   access to the hardware and controls all the operating systems that are running
   on the system.
   The guest OSes have access to the physical hardware, and the hypervisor
-  arbiters this accesses.
-  KVM is an example of Type 1 hypervisor.
+  arbitrates this accesses.
+  KVM is an example of a Type 1 hypervisor.
 
 * The **Type 2 hypervisor**, also known as **hosted hypervisor**, has to go
   through the host operating system to reach the hardware.
   Access to the hardware is emulated, using software components that behave
   in the same way as the hardware ones.
-  An example of Type 2 hypervisor is VirtualBox.
+  An example of a Type 2 hypervisor is VirtualBox.
 
 <Image
   border
@@ -55,7 +55,7 @@ The hypervisors can be classified in 2 categories: Type 1 and Type 2:
 In Figure 1 a comparison between different virtualization systems is illustrated
 and demonstrates how the degree of separation between a "guest application" and
 the hardware and “host” becomes further removed.
-The defined job of the host OS and kernel or hypervisor became that of 1) to
+The defined job of the host OS and kernel or hypervisor became: 1) to
 juggle the runtime of multiple applications and environments; 2) to present a
 subset or non-contiguous representation of hardware resources virtually and
 translate operations, and provide emulation and compatibility between guest and


### PR DESCRIPTION
This PR fixes several minor typos and grammatical errors on the Concepts page to improve readability.