### PR TITLE
Fix 194 linux distribution gpg key

### DIFF
--- a/content/docs/cli/install.mdx
+++ b/content/docs/cli/install.mdx
@@ -94,22 +94,17 @@ sudo apt-get install kraftkit
 ## Fedora/RHEL
 
 We recommend installing KraftKit using the interactive method described above.
-However, you can also directly add our remote RPM package registry entry.
+However, you can also download the latest `kraft` RPM package for your
+architecture directly from GitHub Releases:
 
-First add new entry for `kraftkit` in `/etc/yum.repos.d/kraftkit.repo`:
+https://github.com/unikraft/kraftkit/releases/latest
 
-```toml
-[kraftkit]
-name=KraftKit Repo
-baseurl=https://rpm.pkg.kraftkit.sh
-enabled=1
-gpgcheck=0
-```
+For example, to install on an `x86_64` system:
 
-Then run:
 ```bash
-yum makecache
-yum install -y kraftkit
+KRAFTKIT_VERSION=$(curl -s https://api.github.com/repos/unikraft/kraftkit/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": "\(.*\)".*/\1/')
+curl -LO "https://github.com/unikraft/kraftkit/releases/download/${KRAFTKIT_VERSION}/kraftkit_${KRAFTKIT_VERSION#v}_linux_amd64.rpm"
+sudo rpm -i "kraftkit_${KRAFTKIT_VERSION#v}_linux_amd64.rpm"
 ```
 
 

--- a/content/docs/cli/install.mdx
+++ b/content/docs/cli/install.mdx
@@ -76,6 +76,10 @@ curl -fsSL https://deb.pkg.kraftkit.sh/gpg.key | \
   sudo gpg --dearmor -o /etc/apt/keyrings/unikraft.gpg
 ```
 
+If you are following older instructions and see a `522` error for
+`https://releases.unikraft.org/linux/gpg`, use
+`https://deb.pkg.kraftkit.sh/gpg.key` instead.
+
 Use the following command to set up the APT repository:
 
 ```console

--- a/next-redirect.js
+++ b/next-redirect.js
@@ -62,6 +62,11 @@ async function redirect() {
       permanent: true,
     },
     {
+      source: '/docs/usage/install',
+      destination: '/docs/cli/install',
+      permanent: true,
+    },
+    {
       source: '/docs/concepts/architecture',
       destination: '/docs/internals/architecture',
       permanent: true,


### PR DESCRIPTION
docs: fix broken Linux GPG key install link and add usage-install redirect