### PR TITLE
Resurface usoc22 guides

### DIFF
--- a/content/guides/advanced-porting.mdx
+++ b/content/guides/advanced-porting.mdx
@@ -10,7 +10,7 @@ Today, we will learn how to properly port a more complex application, using mult
 
 We will use [`iperf3`](https://github.com/esnet/iperf/tree/master) as an example, a network benchmarking tool.
 
-### The Unikraft Build Lifecycle
+## The Unikraft Build Lifecycle
 
 The lifecycle of the construction of a Unikraft unikernel includes several distinct steps:
 
@@ -243,14 +243,14 @@ This process is usually very iterative because it requires building the unikerne
    Make an `include/` directory in the library's repository and copy the file:
 
    ```console
-   mkdir ~/workdir/app-iperf/workdir/libs/iperf3/include
-   cp workdir/build/libiperf3/origin/iperf-3.10.1/src/iperf_config.h ~/workdir/app-iperf/.unikraft/libs/iperf3/include
+   $ mkdir ~/workdir/app-iperf/workdir/libs/iperf3/include
+   $ cp workdir/build/libiperf3/origin/iperf-3.10.1/src/iperf_config.h ~/workdir/app-iperf/.unikraft/libs/iperf3/include
    ```
 
    Let's indicate in the `Makefile.uk` of the Unikraft library for `iperf3` that this directory exists, and should be used as a location to look for header files:
    Add this line in the `workdir/libs/iperf3/Makefile.uk` file:
 
-   ```Makefile
+   ```make
    LIBIPERF3_CINCLUDES-y += -I$(LIBIPERF3_BASE)/include
    ```
 
@@ -261,8 +261,8 @@ This process is usually very iterative because it requires building the unikerne
    The `make` might give an error at the end, but it's fine, we can ignore it.
 
    ```console
-   cd workdir/build/libiperf3/origin/iperf-3.14/
-   make -n
+   $ cd workdir/build/libiperf3/origin/iperf-3.14/
+   $ make -n
    ```
 
    This flag, `-n`, has just shown us what `make` will run, the full commands for `gcc` including flags.
@@ -283,14 +283,14 @@ This process is usually very iterative because it requires building the unikerne
    However, in a later step, we'll find out that we can set some flags.
    If you do have flags which are immediately obvious, you set them like so in the library port's `Makefile.uk`, for example:
 
-   ```Makefile
+   ```make
    LIBIPERF3_CFLAGS-y += -Wno-unused-parameter
    ```
 
 1. We have a full list of files for `iperf3` from the previous step.
    We can add them as known source files like so to the Unikraft port of `iperf3`'s `Makefile.uk`:
 
-   ```Makefile
+   ```make
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/main.c
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/cjson.c
    LIBIPERF3_SRCS-y += $(LIBIPERF3_SRC)/iperf_api.c
@@ -311,8 +311,8 @@ This process is usually very iterative because it requires building the unikerne
    Because the application has been configured and we have fetched the contents, we can simply try running the build in the Unikraft application directory:
 
    ```console
-   cd ~/workdir/app-iperf3
-   make
+   $ cd ~/workdir/app-iperf3
+   $ make
    ```
 
 1. (Optional) This step occurs less frequently, but is still useful to discuss in the context of porting an application to Unikraft.
@@ -328,13 +328,13 @@ This process is usually very iterative because it requires building the unikerne
 
    Preparation is done by adding Make targets to the `UK_PREPARE` variable:
 
-   ```Makefile
+   ```make
    UK_PREPARE += mytarget
    ```
 
    Checking whether the library has been prepared or adding a target which requires preparation before it can be executed is as simple as checking whether the following target exists:
 
-   ```Makefile
+   ```make
    $(LIBIPERF3_BUILD)/.patched
    ```
 
@@ -342,7 +342,7 @@ This process is usually very iterative because it requires building the unikerne
    However, it can be called separately from `make` via:
 
    ```console
-   make prepare
+   $ make prepare
    ```
 
 The steps outlined above helped us begin the process of porting a simple application to Unikraft.
@@ -404,18 +404,19 @@ As such, if you update the library or application's code (i.e. by updating, for 
 To make a patch:
 
 1. First, ensure that the remote origin code has been downloaded to the application's `build/` folder:
+
    ```console
-   cd ~/workspace/apps/iperf3
-   make fetch
+   $ cd ~/workspace/apps/iperf3
+   $ make fetch
    ```
 
 1. Once the source files have been downloaded, turn it into a Git repository and save everything to an initial commit, in the case of `iperf3`:
 
    ```console
-   cd workdir/build/libiperf3/origin/iperf-3.10.1
-   git init
-   git add .
-   git commit -m "Initial commit"
+   $ cd workdir/build/libiperf3/origin/iperf-3.10.1
+   $ git init
+   $ git add .
+   $ git commit -m "Initial commit"
    ```
 
    This will allow us to make changes to the source files and save those differences.
@@ -427,21 +428,128 @@ To make a patch:
    For example, if you have made one (`1`) patch only, export it like so:
 
    ```console
-   git format-patch HEAD~1
+   $ git format-patch HEAD~1
    ```
 
-   This will save a new `.patch` file in the current directory; which should be the origin source files of `iperf3`.
+   This will save a new `.patch` file in the current directory;
+   which should be the origin source files of `iperf3`.
 
 1. The next step is to create a `patches/` folder within the Unikraft port of the library and to move the new `.patch` file into this folder:
 
    ```console
-   mkdir ~/workspace/libs/iperf3/patches
-   mv ~/workspace/apps/iperf3/build/libiperf3/origin/iperf-3.10.1/*.patch ~/workspace/libs/iperf3/patches
+   $ mkdir ~/workspace/libs/iperf3/patches
+   $ mv ~/workspace/apps/iperf3/build/libiperf3/origin/iperf-3.10.1/*.patch ~/workspace/libs/iperf3/patches
    ```
 
 1. To register patches against Unikraft's build system such that they are applied before the compilation of all source files, simply indicate it in the library's `Makefile.uk`:
 
-   ```Makefile
+   ```make
    # Add or edit ~/workspace/libs/iperf3/Makefile.uk
    LIBIPERF3_PATCHDIR = $(LIBIPERF3_BASE)/patches
    ```
+
+## Registering Components via ELF Sections
+
+There are situations in which we want to add new sections in the executable file (ELF format) for our application or library.
+These sections are useful for making components much easier to configure.
+For example, the Unikraft virtual filesystem (`vfscore`) uses such a section to register filesystems (like `ramfs` or `9pfs`), and the scheduler uses them to register functions at build time.
+
+To add such a section, you can define a linker script with the `.ld` extension (e.g., `extra.ld`):
+
+```ld
+SECTIONS
+{
+    .my_section : {
+        PROVIDE(my_section_start = .);
+        KEEP (*(.my_section_entry))
+        PROVIDE(my_section_end = .);
+    }
+}
+INSERT AFTER .text;
+```
+
+Then, register the linker script in your `Makefile.uk`:
+
+```make
+LIBYOURAPPNAME_SRCS-$(CONFIG_LIBYOURAPPNAME) += $(LIBYOURAPPNAME_BASE)/extra.ld
+```
+
+Data can be registered in this section using macros that leverage compiler attributes like `__section` and `__used`.
+These macros are typically found in `uk/essentials.h`:
+
+```c
+#define MY_REGISTER(s, f) static const struct my_structure      \
+        __section(".my_section_entry")                          \
+        __my_section_var __used =                               \
+                {.name = (s),                                   \
+                .func = (f)};
+```
+
+Iterating through these registered entries involves using the boundary symbols defined in the linker script:
+
+```c
+extern const struct my_structure my_section_start;
+extern const struct my_structure my_section_end;
+
+#define for_each_entry(iter)                                    \
+        for (iter = &my_section_start;                          \
+                iter < &my_section_end;                         \
+                iter++)
+```
+
+## Integrating with Unikraft Internal APIs
+
+Some applications require direct interaction with Unikraft's internal system APIs.
+For each category of internal library (e.g., memory allocators, schedulers, filesystems, network drivers), Unikraft defines an API that libraries in that category must comply with, allowing different implementations to be plugged in easily.
+
+### The Virtual Filesystem API (vfscore)
+
+The `vfscore` internal library provides the implementation for filesystem-related system calls.
+It maps generic calls like `read` or `write` to specific implementations using function pointers defined in two primary structures:
+
+- `struct vfsops`: Defines filesystem-level operations such as mounting.
+- `struct vnops`: Defines operations on specific file nodes (vnodes).
+
+Filesystems register themselves with `vfscore` using the `vfscore_fs_type` structure and the `UK_FS_REGISTER` macro:
+
+```c
+struct vfscore_fs_type {
+        const char      *vs_name;       /* name of file system */
+        int             (*vs_init)(void); /* initialize routine */
+        struct vfsops   *vs_op;         /* pointer to vfs operation */
+};
+
+UK_FS_REGISTER(fs_ramfs);
+```
+
+Within `vfscore`, files are abstracted as `vnode` structures, which maintain metadata such as operations, permissions, and size.
+They also include a `void *v_data` field for filesystem-specific private data.
+Other key structures include `dentry` for path abstractions and `mount` for associated mount points.
+
+To make a new filesystem configurable, its registration must also be reflected in the `Config.uk` of the `vfscore` library, allowing it to be selected as a root filesystem in `menuconfig`.
+
+## Generic List API in Unikraft
+
+Unikraft includes a generic doubly-linked list implementation, similar to the Linux kernel's, available via `<uk/list.h>`.
+This API uses the `uk_list_head` structure, which can be embedded within any container structure:
+
+```c
+struct car {
+        char name[50];
+        struct uk_list_head list;
+};
+```
+
+Common routines in this API include:
+
+- `UK_LIST_HEAD(name)`: Declares the sentinel of a list globally.
+
+- `UK_INIT_LIST_HEAD(struct uk_list_head *list)`: Initializes a list head dynamically.
+
+- `uk_list_add(struct uk_list_head *new_entry, struct uk_list_head *head)`: Adds an entry.
+
+- `uk_list_entry(ptr, type, field)`: Returns the structure containing the list element.
+
+- `uk_list_for_each(p, head)`: Iterates over a list.
+
+- `uk_list_for_each_safe(p, n, head)`: Iterates safely, allowing for entry deletion.

--- a/content/guides/high-performance.mdx
+++ b/content/guides/high-performance.mdx
@@ -1,0 +1,259 @@
+---
+title: High-Performance Networking
+description: |
+  Developing highly specialized and performance-optimized unikernels with Unikraft by bypassing traditional OS layers and interacting directly with network drivers.
+---
+
+## Overview
+
+In this guide, we explore the development of highly specialized and performance-optimized unikernels.
+Traditionally, network-based applications in Unikraft are built on top of the socket API, which requires a multi-layered library stack:
+
+```text
+.---------------------------.
+(     Socket application    )
+'---------------------------'
+              |
+              V
++---------------------------+
+|         libvfscore        |
++---------------------------+
++---------------------------+
+|          liblwip          |
++---------------------------+
++---------------------------+
+|        libuknetdev        |
++---------------------------+
++---------------------------+
+|        libkvmplat         |
++---------------------------+
+              |
+              V
+.---------------------------.
+( Virtual Network Interface )
+'---------------------------'
+```
+
+The Virtual File System (VFS) layer (provided by `libvfscore`) and the TCP/IP network stack (provided by `liblwip`) are complex subsystems that can introduce additional overhead.
+For high-performance Network Functions (NFs), it is often more efficient to bypass these OS components and interact directly with the driver or hardware, similar to frameworks like Intel DPDK.
+
+In this scenario, the library stack is simplified:
+
+```text
+.---------------------------.
+(    High performance NF    )
+'---------------------------'
+              |
+              V
++---------------------------+
+|        libuknetdev        |
++---------------------------+
++---------------------------+
+|        libkvmplat         |
++---------------------------+
+              |
+              V
+.---------------------------.
+( Virtual Network Interface )
+'---------------------------'
+```
+
+This guide demonstrates the process of developing a high-performance network packet generator using this direct-access model.
+
+## Requirements
+
+To develop and test high-performance networking unikernels, you need the Unikraft `kraft` tool and the following utilities:
+
+- `qemu-kvm`
+- `qemu-system-x86_64`
+- `bridge-utils`
+- `ifupdown`
+- `tshark`
+- `tcpdump`
+
+Installation on Debian/Ubuntu:
+
+```console
+$ sudo apt-get -y install qemu-kvm qemu-system-x86 sgabios socat bridge-utils ifupdown tshark tcpdump
+```
+
+## Getting Started
+
+The development process typically begins with a template containing basic building blocks, such as utilities for crafting IPv4/UDP packets.
+
+1. Create a copy of the packet generator template:
+
+   ```console
+   $ cp -a sol/pktgen path/to/your/copy
+   $ cd path/to/your/copy
+   ```
+
+1. Initialize and build the application with `kraft`:
+
+   ```console
+   $ kraft list update
+   $ kraft list pull
+   $ kraft configure
+   $ kraft build
+   ```
+
+1. Verify the resulting image by running it to see the Unikraft banner:
+
+   ```console
+   $ kraft run
+   ```
+
+## Interacting with the Network Device
+
+Direct interaction with network device drivers is achieved through Unikraft's internal `uknetdev` API.
+
+### Library Dependency
+
+First, ensure the application states a dependency on `libuknetdev` in its `Config.uk` file:
+
+```kconfig
+depends on LIBUKNETDEV
+```
+
+This provides access to the `<uk/netdev.h>` and `<uk/netbuf.h>` headers.
+
+### Bringing Up the Interface
+
+Bringing up a network interface involves transitioning the device through several configuration states before it can process traffic:
+
+1. **Discovery**: Determine the number of available interfaces using `uk_netdev_count()`.
+
+1. **Retrieval**: Retrieve the `struct uk_netdev *` handle for the desired device (e.g., device `0`).
+
+1. **Configuration**: Specify how many receive (RX) and transmit (TX) queues the device should provide.
+   Note that drivers typically require at least one queue in each direction even if only one is used.
+
+   ```c
+   struct uk_netdev_conf ifconf = {
+       .nb_rx_queues = 1,
+       .nb_tx_queues = 1
+   };
+   ```
+
+1. **Queue Setup**: Configure the RX and TX queues, specifying the size and the allocators for internal descriptors and buffers.
+
+1. **Probing**: Use `uk_netdev_probe()` to transition the device from an unprobed to an unconfigured state.
+
+1. **Starting**: Use `uk_netdev_start()` to enable the device for operational traffic.
+
+### Testing Environment
+
+To test the unikernel's networking capabilities, a network bridge must be created on the Linux host:
+
+```console
+# Ensure permissions for STP and create bridge 'usocbr0'
+sudo sysctl -w net.bridge.bridge-nf-call-arptables=0
+sudo brctl addbr usocbr0
+sudo brctl setfd usocbr0 0
+sudo brctl stp usocbr0 off
+sudo ifconfig usocbr0 0.0.0.0 up
+
+# Disable packet filtering on bridge interfaces
+echo 0 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables
+echo 0 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
+echo 0 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables
+```
+
+Launch the unikernel attached to the bridge:
+
+```console
+$ kraft run -b usocbr0
+```
+
+## Packet Generation and Transmission
+
+### Generating Frames
+
+The provided `genpkt_udp4()` function (or the shorthand `genpkt_usoc21()`) generates Ethernet-IPv4-UDP frames.
+The generation requires specific parameters retrieved from the device via `uk_netdev_info_get()`, such as `ioalign` for buffer alignment and `nb_encap_tx` for headroom (reserved space for driver encapsulation).
+
+For performance testing, minimum-sized packets (60 bytes) are recommended, as they place the most stress on software and hardware parsing components.
+
+### Sending Packets
+
+Transmission is performed using `uk_netdev_tx_one()`.
+It is critical to manage the packet buffers correctly:
+
+- If a packet is successfully enqueued, the driver takes ownership and will free it automatically.
+- If transmission fails, the application must manually call `uk_netbuf_free()` to avoid memory leaks.
+
+```c
+status = uk_netdev_tx_one(netif, 0, pkt);
+if (!uk_netdev_status_successful(status)) {
+    uk_netbuf_free(pkt);
+}
+```
+
+Traffic can be verified on the host using tools like `tshark` or `tcpdump` attached to the bridge:
+
+```console
+$ tshark -i usocbr0
+```
+
+## Performance Optimization
+
+### Throttled Instrumentation
+
+Measuring performance requires tracking the total number of packets and bytes sent.
+However, synchronous printing in Unikraft is expensive and can significantly slow down the application.
+It is recommended to throttle statistics printing using a bitmask or counter:
+
+```c
+if ((total_nb_pkts & 0x3fffff) == 0x0) {
+    print_netspeed(total_nb_pkts, total_nb_bytes);
+}
+```
+
+### Optimization Techniques
+
+Several techniques can be applied to increase the packet rate:
+
+1. **Compiler Optimizations**: Enable *Link Time Optimizations* (LTO) and *Dead Code Elimination* (DCE) in the build options via `menuconfig`.
+
+1. **Persistent Packets**: Instead of freeing and regenerating packets on transmission failure, retry sending until the TX queue has space.
+
+1. **Packet Duplication**: Use `uk_netbuf_dup_single()` to `memcpy` from a primordial packet buffer, which can be cheaper than full header generation.
+
+1. **Memory Pools**: Use `libukallocpool` for $O(1)$ allocation and deallocation.
+   This replaces the general-purpose allocator with a pre-allocated list of objects.
+
+   ```c
+   /* Add 'depends on LIBUKALLOCPOOL' to Config.uk */
+   pool = uk_allocpool_alloc(uk_alloc_get_default(), 1024, 2048, info.ioalign);
+   struct uk_alloc *p = uk_allocpool2ukalloc(pool);
+   ```
+
+1. **Zero-copy**: While virtio-net has current limitations, some drivers support increasing the `netbuf` reference counter to avoid freeing and reallocating the same packet for repeated transmission.
+
+1. **Batching**: Sending multiple packets in a single batch reduces the overhead of notifying the device backend (functionality introduced in PR#243).
+
+## Receiving Traffic
+
+Implementing a receiver follows a similar pattern to the transmitter but requires a proper receive buffer allocation function (`alloc_rxpkts`).
+This callback is used by the driver to replenish the RX queue with empty buffers.
+
+```c
+uint16_t alloc_rxpkts(void *argp, struct uk_netbuf *pkts[], uint16_t count) {
+    uint16_t i;
+    for (i=0; i<count; ++i) {
+        pkts[i] = uk_netbuf_alloc_buf(p, 2048, info.ioalign, info.nb_encap_rx, 0, NULL);
+        if (!pkts[i]) break;
+    }
+    return i;
+}
+```
+
+The receive loop then polls the device:
+
+```c
+status = uk_netdev_rx_one(netdev, 0, &pkt);
+if (uk_netdev_status_successful(status)) {
+    // Process counters and free the received packet
+    uk_netbuf_free(pkt);
+}
+```


### PR DESCRIPTION
This PR currently adds the guides ported from sessions 9 and 10 of usoc22: **"Advanced App Porting"**, respectively **"High Performance"**.

For the advanced app porting guide 3 new sections have been added from the usoc22 session:
 1. Registering Components via ELF Sections
 1. Integrating with Unikraft Internal APIs
 1. Generic List API in Unikraft

The high performance session has been directly ported as it's own guide with a slight narration change to fit it better as a guide rather than an interactive workshop session.

@razvand feedback would be greatly appreciated!