### PR TITLE
Fix markdown formatting of guides according to linter

### DIFF
--- a/content/guides/advanced-porting.mdx
+++ b/content/guides/advanced-porting.mdx
@@ -10,7 +10,7 @@ Today, we will learn how to properly port a more complex application, using mult
 
 We will use [`iperf3`](https://github.com/esnet/iperf/tree/master) as an example, a network benchmarking tool.
 
-### The Unikraft Build Lifecycle
+## The Unikraft Build Lifecycle
 
 The lifecycle of the construction of a Unikraft unikernel includes several distinct steps:
 
@@ -404,6 +404,7 @@ As such, if you update the library or application's code (i.e. by updating, for 
 To make a patch:
 
 1. First, ensure that the remote origin code has been downloaded to the application's `build/` folder:
+
    ```console
    cd ~/workspace/apps/iperf3
    make fetch

--- a/content/guides/bincompat.mdx
+++ b/content/guides/bincompat.mdx
@@ -15,25 +15,25 @@ We need to pass the filesystem to the Unikraft application at runtime.
 We will do that by creating a `cpio` archive.
 Also, we will give the program name that we want to run as an argument to elfloader, using `-append`.
 
-### Run a Simple `helloworld` in Bincompat Mode
+## Run a Simple `helloworld` in Bincompat Mode
 
 Follow the instructions from the `README` file of [`elfloader`](https://github.com/unikraft/catalog-core/tree/main/elfloader-basic) and run a simple application.
 The application code that will be compiled and run will be placed in `rootfs/`.
 
-### Modify the `helloworld` Applications
+## Modify the `helloworld` Applications
 
 Make some changes in the code from `rootfs/`.
 Make the application more complex, change it however you want.
 You can add more source files, but make sure to add them to the `Makefile`.
 
-### Use Networking in Bincompat Mode
+## Use Networking in Bincompat Mode
 
 Aplications that need networking will need some extra libraries.
 Follow the instructions in the `README` file.
 For this, we will use the [`elfloader-net`](https://github.com/unikraft/catalog-core/tree/main/elfloader-net) application.
 As in the prevoius sessions, the IP address of the application will be `172.44.0.2`.
 
-### Use a Binary from Your System
+## Use a Binary from Your System
 
 Choose an application from your system.
 You can use something similar to what we used in the last session, `ls`, `id`, `echo`, `cat`, etc.

--- a/content/guides/catalog-behind-the-scenes.mdx
+++ b/content/guides/catalog-behind-the-scenes.mdx
@@ -23,7 +23,7 @@ The build phase creates the output kernel, and the run phase launches a Unikraft
 The kernel is a join of the actual Unikraft kernel and the application filesystem, packed as an initial ramdisk.
 We call the packed initial ramdisk the **embedded initial ramdisk** or **embedded initrd**.
 
-### Configuration
+### NGINX Configuration
 
 The build and run configuration is part of the [`Kraftfile`](https://github.com/unikraft/catalog/blob/main/library/nginx/1.25/Kraftfile).
 
@@ -33,8 +33,10 @@ The `Kraftfile` defines the:
 - the command line to start the application: `/usr/bin/nginx`
 - path to the template `app-elfloader`
 - paths and versions of repositories (`unikraft`, `lwip`, `libelf`)
-- configuration options: i.e. the `CONFIG_...` option enables the emdedded initrd build
-- build and run targets: currently only x86_64-based builds are available, and only KVM-based builds, using QEMU or Firecracker
+- configuration options:
+  i.e. the `CONFIG_...` option enables the embedded initrd build
+- build and run targets: currently only x86_64-based builds are available,
+  and only KVM-based builds, using QEMU or Firecracker
 - root filesystem used to build the (embedded) initrd
 
 The root filesystem is generated from a `Dockerfile` specification, as configured in the `Kraftfile`.
@@ -109,11 +111,12 @@ The resulting embedded kernel image is `.unikraft/build/nginx_qemu-x86_64`:
 ```bash
 $ ls -lh .unikraft/build/nginx_qemu-x86_64
 ```
-```
+
+```text
 -rwxr-xr-x 2 razvand docker 15M Jan  2 21:23 .unikraft/build/nginx_qemu-x86_64
 ```
 
-### Run Phase
+### NGINX Run Phase
 
 This image is run with a command such as:
 
@@ -191,7 +194,7 @@ cmd: ["/server"]
 
 The `Kraftfile` defines:
 
-- the runtime image to use, containing the kernel: `unikraft.org/base:latest' (it can be summarized as just `base:latest`)
+- the runtime image to use, containing the kernel: `unikraft.org/base:latest` (it can be summarized as just `base:latest`)
 - the root filesystem used, defined in a `Dockerfile`
 - the command line to start the application: `/server`
 - the available run targets: currently only x86_64-based builds are available, and only KVM-based builds, using QEMU or Firecracker
@@ -224,7 +227,7 @@ COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/
 
 The Dockerfile is being interpreted via [BuildKit](https://docs.docker.com/build/buildkit/), hence the need to set up the BuildKit container.
 
-### Run Phase
+### HTTP Go Server Run Phase
 
 The run command requires the `BuildKit` container to be configured beforehand:
 
@@ -251,9 +254,10 @@ kraft run -W -p 8080:8080 .
 The resulting initrd image is `.unikraft/build/initramfs.cpio`.
 
 ```bash
-$ ls -lh .unikraft/build/initramfs.cpio
+$ ls -lh .unikraft/build/initramfs*.cpio
 ```
-```
+
+```text
 -rw-r--r-- 1 root root 8.9M Jan  4 18:16 .unikraft/build/initramfs-x86_64.cpio
 ```
 
@@ -262,7 +266,8 @@ To view the contents of the root filesystem you can use `cpio`:
 ```bash
 $ cpio -itv < .unikraft/build/initramfs.cpio
 ```
-```
+
+```text
 d---------   0 root     root            0 Jan  1  1970 /lib
 d---------   0 root     root            0 Jan  1  1970 /lib/x86_64-linux-gnu
 -rwxr-xr-x   1 root     root      1922136 Sep 30 11:31 /lib/x86_64-linux-gnu/libc.so.6

--- a/content/guides/catalog-using-firecracker.mdx
+++ b/content/guides/catalog-using-firecracker.mdx
@@ -169,7 +169,8 @@ Use the steps below to build and run the HTTP Go server as a binary-compatible a
    ```bash
    $ ls -lh .unikraft/build/initramfs-x86_64.cpio
    ```
-   ```
+
+   ```text
    -rw-r--r-- 1 razvand razvand 9.7M Jan 26 18:50 .unikraft/build/initramfs-x86_64.cpio
    ```
 

--- a/content/guides/debugging.mdx
+++ b/content/guides/debugging.mdx
@@ -21,7 +21,7 @@ Below you can see a list of useful commands.
 
 Today we'll make use of `gdb`.
 We recommend the [following cheat sheet](https://darkdust.net/files/GDB%20Cheat%20Sheet.pdf) for the most common commands.
-A quick crash course on GDB may be found [here](https://www.cs.umd.edu/~srhuang/teaching/cmsc212/gdb-tutorial-handout.pdf).
+A quick crash course on GDB may be found in this [GDB tutorial](https://www.cs.umd.edu/~srhuang/teaching/cmsc212/gdb-tutorial-handout.pdf).
 
 ## Debugging
 
@@ -132,11 +132,11 @@ If you want to dereference a pointer and actually see the value, you can use the
 (gdb) p *addr
 ```
 
-You can find more GDB commands [here](https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf)
-Also, if you are unfamiliar with X86_64 calling convention you can read more about it [here](https://en.wikipedia.org/wiki/X86_calling_conventions).
+You can find more GDB commands in this [GDB reference card](https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf).
+Also, if you are unfamiliar with X86_64 calling convention you can read more about it in this [X86_64 calling convention article](https://en.wikipedia.org/wiki/X86_calling_conventions).
 
 Now, let's get back to the task.
-Download the target kernel image from [here](https://github.com/unikraft-upb/guides-exercises/raw/refs/heads/master/debugging/02-secret/mystery_kvm-x86_64.dbg).
+Download the target kernel image from the [guides-exercises repository](https://github.com/unikraft-upb/guides-exercises/raw/refs/heads/master/debugging/02-secret/mystery_kvm-x86_64.dbg).
 
 Use `qemu` and `gdb` to navigate through the `mystery_kvm-x86_64.dbg` file.
 
@@ -155,15 +155,18 @@ gdb --eval-command="target remote :1234" mystery_kvm-x86_64.dbg
 Do you think you can find out the **secret**?
 
 1. Look through the assembly code and see what it does.
-   Follow the `test eax, eax` instructions and see what needs to happen to pass those tests and get to the last point where the secret is printed (i.e. be able to advance to address `0x000000000018a4ae`).
+   Follow the `test eax, eax` instructions and see what needs to happen to pass those tests and get to the last point where the secret is printed.
+   This will allow you to advance to address `0x000000000018a4ae`.
 
-1. Investigate memory addresses (using the `x` instruction - such as `x/s $rbp-0x120`), do instruction stepping (`stepi` or `nexti`), use breakpoints (`break *<address>`) and find out the secret.
+1. Investigate memory addresses (using the `x` instruction - such as `x/s $rbp-0x120`), do instruction stepping (`stepi` or `nexti`),
+   use breakpoints (`break *<address>`) and find out the secret.
 
 ### 03. Nginx with or without main? That's the question
 
 Let's try a new application based on networking, **Nginx**.
 
-Use the same setup from the last session, follow the instructions in the [`README.md` file from the catalog repository](https://github.com/unikraft/catalog-core/tree/main/nginx) and build `Nginx` for Qemu/KVM.
+Use the same setup from the last session,
+follow the instructions in the [`README.md` file from the catalog repository](https://github.com/unikraft/catalog-core/tree/main/nginx) and build `Nginx` for Qemu/KVM.
 Do you observe something strange?
 Where is the `main.c` file?
 

--- a/content/guides/internals.mdx
+++ b/content/guides/internals.mdx
@@ -14,7 +14,7 @@ Let's start by understanding the basic layout of the Unikraft working directory,
 We are also going to take a look at how we can build basic applications and how we can extend their functionality and support by adding ported external libraries.
 
 Before everything, we shall take a bird's eye view of what Unikraft is and what we can do with it.
-Unikraft is a unikernel [SDK](https://en.wikipedia.org/wiki/Software_development_kit), meaning it offers you the blocks (source code, configuration and build system, runtime support) to build and run unikernels (i.e. applications such as `redis`, `nginx` or `sqlite`).
+Unikraft is a unikernel [SDK](https://en.wikipedia.org/wiki/Software_development_kit), meaning it offers you the blocks (source code, configuration and build system, runtime support) to build and run unikernels (i.e., applications such as `redis`, `nginx` or `sqlite`).
 A unikernel is a single image file that can be loaded and run as a separate running instance, most often a virtual machine.
 
 Summarily, the Unikraft components are shown in the image below:
@@ -37,8 +37,8 @@ It typically provides the `main()` function (or equivalent) and is reliant on Un
 Applications that have been ported on top of Unikraft are located in repositories in the [Unikraft organization](https://github.com/unikraft/), those whose names start with `app-`.
 
 An important role of the core Unikraft component is providing support for different platforms and architectures.
-A platform is the virtualization / runtime environment used to run the resulting image (i.e QEMU, Firecracker, VMWare etc.).
-An architecture details the CPU and memory specifics that will run the resulting image (i.e. x86, ARM).
+A platform is the virtualization / runtime environment used to run the resulting image (i.e., QEMU, Firecracker, VMWare etc.).
+An architecture details the CPU and memory specifics that will run the resulting image (i.e., x86, ARM).
 
 We can  use a lower-level configuration and build system (based on [Kconfig](https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html) and [make](https://www.gnu.org/software/make/)) to get a grasp of how everything works.
 The low-level system will be further detailed in the next session.
@@ -105,7 +105,8 @@ $ make menuconfig
 
 This will open a menu-driven user interface in which you can choose the target architecture, virtualization platform, and configuration options for both internal and external libraries of the resulting unikernel image.
 
-We are met with the following configuration menu. Let's pick the x86 architecture:
+We are met with the following configuration menu.
+Let's pick the x86 architecture:
 
 ![arch selection menu](/images/menuconfig_select_arch.png)
 
@@ -146,7 +147,9 @@ The process should end with the following output:
   GZ      c-hello_qemu-x86_64.gz
 make[1]: Leaving directory '/projects/unikraft/catalog-core/repos/unikraft'
 ```
-Notice that each line in `make`'s output consists of an operation in the build process (i.e compiling, linking, symbol striping etc.) and a corresponding generated file.
+
+Notice that each line in `make`'s output consists of an operation in the build process (i.e., compiling, linking, symbol stripping etc.)
+and a corresponding generated file.
 
 ### Running
 
@@ -196,7 +199,9 @@ When you exit the menu, you will most likely see this warning message:
 *** This is to ensure that the new setting is applied
 *** to every compilation unit.
 ```
-This is a very good recommandation and you'll use it a lot when configuring and building applications - so make sure to run
+
+This is a very good recommendation and you'll use it a lot when configuring and building applications.
+So make sure to run
 
 ```console
 $ make properclean
@@ -209,7 +214,8 @@ $ make -j$(nproc)
 ```
 
 ...to finally build an ARM64 unikernel.
-Since we are targeting a different architecture, we have to use QEMU to emulate an ARM64 CPU:
+Since we are targeting a different architecture,
+we have to use QEMU to emulate an ARM64 CPU:
 
 ```console
 $ qemu-system-aarch64 -kernel workdir/build/c-hello_qemu-arm64 -nographic -machine virt -cpu cortex-a57
@@ -217,7 +223,9 @@ $ qemu-system-aarch64 -kernel workdir/build/c-hello_qemu-arm64 -nographic -machi
 
 The `-kernel` and `-nographic` are the same as in the x86 case.
 The `-machine` option is used to specify which `ARM` board we want to emulate.
-We can choose among Raspberry PI, Siemens, NXP boards and so on, but we are instead using the generic platform `virt`, which does not correspond to real hardware and is the board [recommended by QEMU](https://www.qemu.org/docs/master/system/arm/virt.html) to run guests.
+We can choose among Raspberry PI, Siemens, NXP boards and so on,
+but we are instead using the generic platform `virt`,
+which does not correspond to real hardware and is the board [recommended by QEMU](https://www.qemu.org/docs/master/system/arm/virt.html) to run guests.
 Lastly, the `-cpu` option is used for specifying the CPU whose ISA we want to emulate.
 Some CPUs differ, for example, with regards to the [extensions](https://sourceware.org/binutils/docs/as/AArch64-Extensions.html) they implement.
 The `cortex-a57` is sufficient for our examples.
@@ -234,6 +242,7 @@ oOo oOO| | | | |   (| | | (_) |  _) :_
                   Atlas 0.13.1~5eb820bd
 Hello from Unikraft!
 ```
+
 ### Enabling kernel logs
 
 We will now try to further configure our `c-hello` application.
@@ -256,7 +265,8 @@ To do this, we can proceed to the `Library Configuration` menu:
 
 ![library selection menu](/images/menuconfig_select_library.png)
 
-We can then see all of Unikraft's internal libraries listed. Scroll down to `ukdebug`, and hit enter:
+We can then see all of Unikraft's internal libraries listed.
+Scroll down to `ukdebug`, and hit enter:
 
 ![ukdebug select1](/images/menuconfig_select_ukdebug.png)
 
@@ -269,11 +279,14 @@ We want to see all the messages (info, warnings, errors) logged by the kernel.
 
 As before, press the `Save` button and exit the configuration menu by repeatedly selecting `Exit`.
 
-Now, if we build and run the application in the same manner (i.e with `$ make -j $(nproc)`, followed by  `$ qemu-system-x86_64 -kernel build/c-hello_qemu-x86_64 -nographic`), we should see a more detailed output:
+Now, if we build and run the application in the same manner (i.e., with `$ make -j $(nproc)`, followed by  `$ qemu-system-x86_64 -kernel build/c-hello_qemu-x86_64 -nographic`),
+we should see a more detailed output:
 
 ```console
 $ qemu-system-x86_64 -kernel build/c-hello_qemu-x86_64 -nographic
+```
 
+```text
 SeaBIOS (version Arch Linux 1.16.2-1-1)
 
 
@@ -323,7 +336,9 @@ You should get an output similar to this one:
 
 ```console
 $ qemu-system-x86_64 -kernel build/c-hello_qemu-x86_64 -nographic
+```
 
+```text
 SeaBIOS (version Arch Linux 1.16.2-1-1)
 
 

--- a/content/guides/overview.mdx
+++ b/content/guides/overview.mdx
@@ -134,7 +134,7 @@ Try to run the foolowing applications for both `x86_64` and `arm64`.
 * [`python3-hello`](https://github.com/unikraft/catalog-core/tree/scripts/python3-hello)
 
 For applications that wait for connections (i.e. `nginx`, `*-http`, `redis`), the VM IP address is `172.44.0.2`.
-You can curl `172.44.0.2` for `nginx`, `172.44.0.2:8080` for `*-http`, and you must use [`redis-cli`](https://redis.io/docs/latest/develop/tools/cli/) for the `redis` application.
+You can `curl` `172.44.0.2` for `nginx`, `172.44.0.2:8080` for `*-http`, and you must use [`redis-cli`](https://redis.io/docs/latest/develop/tools/cli/) for the `redis` application.
 To use `redis-cli`, you can use:
 
 ```console

--- a/content/guides/using-the-app-catalog.mdx
+++ b/content/guides/using-the-app-catalog.mdx
@@ -19,7 +19,8 @@ You can list the applications in the registry by using:
 ```bash
 kraft pkg ls --apps --all --update
 ```
-```
+
+```text
 TYPE  NAME                     VERSION  FORMAT  MANIFEST  INDEX    PLAT
 app   unikraft.org/base        latest   oci     18cd70e   af5c5ed  qemu/x86_64
 app   unikraft.org/base        latest   oci     ac5efa1   af5c5ed  fc/x86_64
@@ -57,7 +58,7 @@ kraft run -W unikraft.org/helloworld
 This will default to the `x86_64` architecture and to the `qemu` platform.
 It will pull and run run the application from the registry:
 
-```
+```text
  i  using arch=x86_64 plat=qemu
 [+] pulling unikraft.org/helloworld
 o.   .o       _ _               __ _
@@ -84,7 +85,8 @@ Similarly, we can pull and run Nginx:
 ```bash
 kraft run -W unikraft.org/nginx:1.15
 ```
-```
+
+```text
  i  using arch=x86_64 plat=qemu
 [+] pulling unikraft.org/nginx
 o.   .o       _ _               __ _
@@ -101,7 +103,8 @@ In order to connect to it, we need to pass a port mapping, similar to [`docker` 
 ```bash
 kraft run -W -p 8080:80 unikraft.org/nginx:1.15
 ```
-```
+
+```text
  i  using arch=x86_64 plat=qemu
 [+] pulling unikraft.org/nginx
 Powered by
@@ -112,7 +115,6 @@ oOo oOO| | | | |   (| | | (_) |  _) :_
  OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
                  Telesto 0.16.1~b1fa7c5
 ```
-
 
 <Info>
 You can use Nginx version 1.25 instead of version 1.15 by appending `:1.25` to the `kraft run` command.
@@ -125,7 +127,8 @@ Query the server to get the index page:
 ```bash
 curl localhost:8080
 ```
-```
+
+```text
 <!DOCTYPE html>
 <html>
 <head>
@@ -148,7 +151,8 @@ First create a bridge interface, as `root` (prefix with `sudo` if required):
 ```bash
 sudo kraft run --network virbr0 unikraft.org/nginx:1.15
 ```
-```
+
+```text
  i  using arch=x86_64 plat=qemu
 [+] pulling unikraft.org/nginx
 en1: Interface is up
@@ -166,7 +170,8 @@ The IP address used is typically the first available address (`172.44.0.2`, if t
 ```bash
 curl 172.44.0.2
 ```
-```
+
+```text
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
This PR fixes some common recurring markdown formatting errors in the Unikraft guides, as pointed out by markdownlint.

The most common error was MD104 (One Sentence per Line). It seems that this error is also caued by abbreviations such as `i.e. or e.g.` and structures like `...`. Errors in such cases aren't taken into account.

Code blocks have been formatted appropriately, with text headers being given to the unlabeled ones and blank lines between the fences being introduced.

Heading order has also been fixed and duplicate header names have been renamed appropriately to fit their context.

Lists now all use `1. 1. 1.` for their ordering and non descriptive labels have been given appropriate names.

`advanced-porting.mdx` contained some formatting errors too, but it's been left untouched as it will be replaced via [this PR](https://github.com/unikraft/docs/pull/551), where it's formatting issues are solved.