### PR TITLE
Fix Docker node_modules and search_meta shadowing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM node:20-alpine AS base
 # Install dependencies only when needed
 FROM base AS dev
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-
-RUN apk add --no-cache libc6-compat
+# libc6-compat & gcompat are needed for native modules (e.g. esbuild) on alpine.
+# openssl is required for HTTPS requests (Octokit).
+# git is required for husky, lint-staged, and metadata scripts.
+RUN apk add --no-cache libc6-compat gcompat openssl git
 
 WORKDIR /docs
 
@@ -13,7 +15,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 # Install dependencies separately to leverage Docker cache
 COPY package.json package-lock.json ./
-RUN npm install --ignore-scripts
+# Bypass postinstall since it requires source code which isn't copied yet
+RUN npm pkg delete scripts.postinstall && npm install
 
 # Copy source code
 COPY . .
@@ -45,6 +48,7 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN set -xe; \
+    apk add --no-cache openssl; \
     addgroup --system --gid 1001 nodejs; \
     adduser --system --uid 1001 nextjs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,15 @@ WORKDIR /docs
 ENV NODE_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Install dependencies separately to leverage Docker cache
+COPY package.json package-lock.json ./
+RUN npm install --ignore-scripts
+
+# Copy source code
 COPY . .
 
-RUN npm install
-
-CMD ["npm", "run", "dev"]
+# Generate search-meta at runtime so it populates the mounted volume, then start dev
+CMD ["sh", "-c", "npm run search-meta:gen && npm run dev"]
 
 # Rebuild the source code only when needed
 FROM dev AS builder

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is deployed on the [Unikraft website](https://unikraft.org/)
 It provides information for the latest version of [Unikraft](https://github.com/unikraft/unikraft) and [KraftKit](https://kraftkit.sh).
 
 Documentation is written in [MDX](https://mdxjs.com/) format.
-Building and deploying it requires Node and NPM.
+Building and deploying it requires Node and npm.
 You can build and run either natively or using Docker.
 
 ## Building and Testing Natively
@@ -29,7 +29,7 @@ For local development:
 ```console
 docker build -t ghcr.io/unikraft/docs:dev --target dev .
 
-docker run -it --rm -v $(pwd):/docs -w /docs -p 3000:3000 ghcr.io/unikraft/docs:dev
+docker run -it --rm -v $(pwd):/docs -v unikraft_modules:/docs/node_modules -w /docs -p 3000:3000 ghcr.io/unikraft/docs:dev
 ```
 
 For production deployment:


### PR DESCRIPTION
This commit fixes #554 which is caused by the container not having access to installed `node_modules` directory, there being the possibly of it getting overwritten / shadowed by a currently existing one. The instructions in `README.md` have been accordingly to fix this problem by forcing the use of the containers node_modules directory.

During testing I also discovered the possibility of the search-meta configuration getting overwritten, so the Dockerfile has been updated to generate it at runtime, preventing this issue.