### PR TITLE
fix(content): Remove 'v' from unikraft version specification

### DIFF
--- a/content/docs/cli/reference/kraftfile/v0.6.mdx
+++ b/content/docs/cli/reference/kraftfile/v0.6.mdx
@@ -290,11 +290,11 @@ spec: v0.6
 name: helloworld
 
 # Short-hand for a specific version of Unikraft
-unikraft: v0.14.0
+unikraft: 0.14.0
 
 # Long-hand for a specific version of Unikraft
 unikraft:
-  version: v0.14.0
+  version: 0.14.0
 
 # Short-hand for a specific commit of Unikraft
 unikraft: 70bc0af


### PR DESCRIPTION
I've stumble into this typo (took me a minute to try without the 'v' character).